### PR TITLE
Draft leaderboard: minimum 5 games for overall win rate + UI

### DIFF
--- a/src/app/draft-history/leaderboard/LeaderboardClient.tsx
+++ b/src/app/draft-history/leaderboard/LeaderboardClient.tsx
@@ -155,7 +155,7 @@ export default function LeaderboardClient({
                         <span className="text-[10px] text-gray-600">
                           {sortBy === "winRate"
                             ? showPlacementTooltip
-                              ? <><span className="text-indigo-400/70 bg-indigo-400/10 rounded px-1.5 py-px mr-1.5">min 5 drafts for full win %</span>{row.wins}W {row.losses}L</>
+                              ? <><span className="text-gray-500">min 5 drafts for full win % ·</span> {row.wins}W {row.losses}L</>
                               : `${row.wins}W ${row.losses}L`
                             : sortBy === "wins"
                               ? `${formatWinRate(row.winRate)}%`

--- a/src/app/draft-history/leaderboard/LeaderboardClient.tsx
+++ b/src/app/draft-history/leaderboard/LeaderboardClient.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { getLeaderboardProfileHref } from "@/lib/draftHistoryLeaderboardPath";
 import { Pagination } from "@/components/ui/pagination";
-import { CheckCircle2, ChevronRight, User } from "lucide-react";
+import { CheckCircle2, ChevronRight, User, X } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import type { DraftLeaderboardRow } from "@/server/draftLeaderboard";
 import {
@@ -14,6 +14,15 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 
 type SortKey = "wins" | "winRate" | "games" | "losses";
 const SORT_OPTIONS: { key: SortKey; label: string }[] = [
@@ -32,6 +41,10 @@ function sortRows(rows: DraftLeaderboardRow[], key: SortKey): DraftLeaderboardRo
     if (key !== "wins" && b.wins !== a.wins) return b.wins - a.wins;
     return b.games - a.games;
   });
+}
+
+function formatWinRate(rate: number): string {
+  return rate % 1 === 0 ? rate.toFixed(0) : rate.toFixed(1);
 }
 
 export default function LeaderboardClient({
@@ -83,6 +96,10 @@ export default function LeaderboardClient({
           </h1>
           <p className="mt-1 text-[13px] text-gray-500">
             Verified drafts only
+            <span className={`inline-block transition-all duration-300 ease-out ${sortBy === "winRate" ? "opacity-100 translate-x-0" : "opacity-0 -translate-x-1 pointer-events-none"}`}>
+              <span className="text-gray-700 mx-1.5">·</span>
+              <WinRateExplainerDialog />
+            </span>
           </p>
         </div>
         <div className="flex flex-wrap items-center justify-end gap-2">
@@ -105,7 +122,8 @@ export default function LeaderboardClient({
           <div className="rounded-lg border border-gray-800 divide-y divide-gray-800/60">
             {paginatedRows.map((row, index) => {
               const rank = (currentPage - 1) * ITEMS_PER_PAGE + index + 1;
-              return (
+              const showPlacementTooltip = sortBy === "winRate" && row.games < 5;
+              const linkContent = (
                 <Link
                   key={row.id}
                   href={getLeaderboardProfileHref(row.id, row.userName)}
@@ -125,9 +143,9 @@ export default function LeaderboardClient({
                         {row.isVerified ? <VerifiedCheck /> : null}
                       </span>
                       <div className="flex flex-col items-end flex-shrink-0 tabular-nums">
-                        <span className="text-sm font-semibold text-gray-200">
+                        <span className={`text-sm font-semibold ${showPlacementTooltip ? "text-gray-400" : "text-gray-200"}`}>
                           {sortBy === "winRate"
-                            ? `${row.winRate.toFixed(1)}%`
+                            ? `${formatWinRate(row.winRate)}%`
                             : sortBy === "wins"
                               ? `${row.wins}W`
                               : sortBy === "losses"
@@ -136,11 +154,13 @@ export default function LeaderboardClient({
                         </span>
                         <span className="text-[10px] text-gray-600">
                           {sortBy === "winRate"
-                            ? `${row.wins}W ${row.losses}L`
+                            ? showPlacementTooltip
+                              ? <><span className="text-indigo-400/70 bg-indigo-400/10 rounded px-1.5 py-px mr-1.5">min 5 drafts for full win %</span>{row.wins}W {row.losses}L</>
+                              : `${row.wins}W ${row.losses}L`
                             : sortBy === "wins"
-                              ? `${row.winRate.toFixed(1)}%`
+                              ? `${formatWinRate(row.winRate)}%`
                               : sortBy === "losses"
-                                ? `${row.winRate.toFixed(1)}%`
+                                ? `${formatWinRate(row.winRate)}%`
                                 : `${row.wins}W ${row.losses}L`}
                         </span>
                       </div>
@@ -148,7 +168,7 @@ export default function LeaderboardClient({
                     {sortBy === "winRate" && (
                       <div className="h-1 rounded-full bg-gray-800 overflow-hidden">
                         <div
-                          className="h-full rounded-full bg-indigo-400/60 transition-all duration-700 ease-out"
+                          className={`h-full rounded-full transition-all duration-700 ease-out ${row.games < 5 ? "bg-indigo-400/25" : "bg-indigo-400/60"}`}
                           style={{
                             width: animate
                               ? `${Math.min(100, Math.max(0, row.winRate))}%`
@@ -162,6 +182,23 @@ export default function LeaderboardClient({
                   <ChevronRight className="w-3.5 h-3.5 text-gray-700 group-hover:text-gray-500 transition-colors duration-100 flex-shrink-0" />
                 </Link>
               );
+
+              if (showPlacementTooltip) {
+                return (
+                  <TooltipProvider key={row.id} delayDuration={400}>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        {linkContent}
+                      </TooltipTrigger>
+                      <TooltipContent side="bottom" className="text-xs">
+                        Under 5 drafts played — win rate counted as {row.wins} out of 5
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
+                );
+              }
+
+              return linkContent;
             })}
           </div>
 
@@ -175,6 +212,60 @@ export default function LeaderboardClient({
         </>
       )}
     </>
+  );
+}
+
+function WinRateExplainerDialog() {
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <button
+          type="button"
+          className="text-xs font-medium text-indigo-400/80 hover:text-indigo-400 transition-colors shrink-0"
+        >
+          Learn more
+        </button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogClose className="absolute right-3 top-3 text-gray-500 hover:text-gray-300 transition-colors">
+          <X className="h-4 w-4" />
+        </DialogClose>
+        <DialogHeader>
+          <DialogTitle>How Win Rate % Works</DialogTitle>
+          <DialogDescription>
+            Players need at least 5 drafts for a full win rate.
+            Until then, wins are divided by 5 instead of total games.
+          </DialogDescription>
+        </DialogHeader>
+        <div className="mt-3 space-y-3 text-sm text-gray-300">
+          <p className="text-[13px] text-gray-400">
+            Win Rate = Wins / (Total Games or 5, whichever is higher)
+          </p>
+          <div className="rounded-md bg-gray-800/50 px-3 py-2.5 space-y-1.5 text-xs tabular-nums">
+            <p className="text-gray-400 text-[11px] mb-1">Under 5 drafts</p>
+            <div className="flex justify-between">
+              <span className="text-gray-400">2-0 record</span>
+              <span>2 / 5 = 40%</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-400">4-1 record</span>
+              <span>4 / 5 = 80%</span>
+            </div>
+          </div>
+          <div className="rounded-md bg-gray-800/50 px-3 py-2.5 space-y-1.5 text-xs tabular-nums">
+            <p className="text-gray-400 text-[11px] mb-1">5+ drafts (normal)</p>
+            <div className="flex justify-between">
+              <span className="text-gray-400">7-3 record</span>
+              <span>7 / 10 = 70%</span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-400">12-8 record</span>
+              <span>12 / 20 = 60%</span>
+            </div>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
   );
 }
 
@@ -213,3 +304,4 @@ function VerifiedCheck() {
     </TooltipProvider>
   );
 }
+

--- a/src/app/draft-history/leaderboard/LeaderboardClient.tsx
+++ b/src/app/draft-history/leaderboard/LeaderboardClient.tsx
@@ -166,7 +166,7 @@ export default function LeaderboardClient({
                     {sortBy === "winRate" && (
                       <div className="h-1 rounded-full bg-gray-800 overflow-hidden">
                         <div
-                          className={`h-full rounded-full transition-all duration-700 ease-out ${row.games < 5 ? "bg-indigo-400/25" : "bg-indigo-400/60"}`}
+                          className={`h-full rounded-full transition-all duration-700 ease-out ${row.games < 5 ? "bg-gray-600" : "bg-indigo-400/60"}`}
                           style={{
                             width: animate
                               ? `${Math.min(100, Math.max(0, row.winRate))}%`

--- a/src/app/draft-history/leaderboard/LeaderboardClient.tsx
+++ b/src/app/draft-history/leaderboard/LeaderboardClient.tsx
@@ -154,9 +154,7 @@ export default function LeaderboardClient({
                         </span>
                         <span className="text-[10px] text-gray-600">
                           {sortBy === "winRate"
-                            ? showPlacementTooltip
-                              ? <><span className="text-gray-500">min 5 drafts for full win % ·</span> {row.wins}W {row.losses}L</>
-                              : `${row.wins}W ${row.losses}L`
+                            ? `${row.wins}W ${row.losses}L`
                             : sortBy === "wins"
                               ? `${formatWinRate(row.winRate)}%`
                               : sortBy === "losses"

--- a/src/app/draft-history/leaderboard/[clerkUserId]/PlayerDrilldownClient.tsx
+++ b/src/app/draft-history/leaderboard/[clerkUserId]/PlayerDrilldownClient.tsx
@@ -203,10 +203,16 @@ export default function PlayerDrilldownClient({
 
   const drilldown = initialData;
 
-  const overallPie = [
-    { name: "Wins", value: drilldown.overall.wins },
-    { name: "Losses", value: drilldown.overall.losses },
-  ];
+  const overallIsAdjusted = drilldown.overall.games < 5;
+  const overallPie = overallIsAdjusted
+    ? [
+        { name: "Wins", value: drilldown.overall.wins },
+        { name: "Remaining", value: 5 - drilldown.overall.wins },
+      ]
+    : [
+        { name: "Wins", value: drilldown.overall.wins },
+        { name: "Losses", value: drilldown.overall.losses },
+      ];
   const captainPie = [
     { name: "Wins", value: drilldown.captain.wins },
     { name: "Losses", value: drilldown.captain.losses },

--- a/src/app/draft-history/leaderboard/[clerkUserId]/PlayerDrilldownClient.tsx
+++ b/src/app/draft-history/leaderboard/[clerkUserId]/PlayerDrilldownClient.tsx
@@ -13,7 +13,7 @@ import {
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
-import { ArrowLeft, CheckCircle2, ChevronDown, ChevronRight, User, Share, Check } from "lucide-react";
+import { ArrowLeft, CheckCircle2, ChevronDown, ChevronRight, User, Share, Check, X } from "lucide-react";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
 import { toast } from "sonner";
 import {
@@ -31,8 +31,21 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import type { DraftClassLeaderboardRow } from "@/server/draftStats";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
 import { allClasses } from "@/app/draft/constants";
 const PIE_COLORS = ["#818cf8", "#374151"];
+
+function formatWinRate(rate: number): string {
+  return rate % 1 === 0 ? rate.toFixed(0) : rate.toFixed(1);
+}
 
 const getBreakdownBarClass = (label: string): string => {
   const normalized = label.trim().toLowerCase();
@@ -302,6 +315,12 @@ export default function PlayerDrilldownClient({
           data={overallPie}
           record={`${drilldown.overall.wins}-${drilldown.overall.losses}`}
           winRate={drilldown.overall.winRate}
+          placementInfo={drilldown.overall.games < 5 ? {
+            playerName: drilldown.playerName,
+            wins: drilldown.overall.wins,
+            losses: drilldown.overall.losses,
+            adjustedRate: drilldown.overall.winRate,
+          } : undefined}
         />
         {drilldown.captain.games > 0 ? (
           <StatCard
@@ -434,7 +453,7 @@ export default function PlayerDrilldownClient({
                         >
                           <span className="truncate text-xs text-gray-200">{row.className}</span>
                           <span className="text-right text-xs tabular-nums text-gray-300">
-                            {row.winRate.toFixed(1)}
+                            {formatWinRate(row.winRate)}
                           </span>
                           <span className="text-right text-xs tabular-nums text-gray-300">
                             {row.wins}
@@ -509,7 +528,7 @@ export default function PlayerDrilldownClient({
                               </span>
                               <span className="inline-flex flex-col items-end leading-tight">
                                 <span className="whitespace-nowrap text-[11px] tabular-nums text-gray-300">
-                                  {row.winRate.toFixed(1)}%
+                                  {formatWinRate(row.winRate)}%
                                 </span>
                                 <span className="whitespace-nowrap text-[10px] tabular-nums text-gray-500">
                                   {row.wins}-{row.losses}
@@ -628,7 +647,7 @@ export default function PlayerDrilldownClient({
                       </span>
                     </div>
                     <span className="text-[11px] text-gray-500 tabular-nums text-right">
-                      {row.winRate.toFixed(1)}%
+                      {formatWinRate(row.winRate)}%
                     </span>
                   </div>
                 ))}
@@ -674,7 +693,7 @@ export default function PlayerDrilldownClient({
                         {row.wins}-{row.losses}
                       </span>
                       <span className="text-gray-600 w-12 text-right text-xs">
-                        {row.winRate.toFixed(1)}%
+                        {formatWinRate(row.winRate)}%
                       </span>
                       {row.opponentIsVerified ? (
                         <ChevronRight className="w-3 h-3 text-gray-700 group-hover:text-gray-500 transition-colors duration-100" />
@@ -778,7 +797,7 @@ export default function PlayerDrilldownClient({
                           </span>
                         </div>
                         <span className="text-[11px] text-gray-500 tabular-nums text-right">
-                          {row.winRate.toFixed(1)}%
+                          {formatWinRate(row.winRate)}%
                         </span>
                       </div>
                     );
@@ -821,7 +840,7 @@ export default function PlayerDrilldownClient({
                           {row.wins}-{row.losses}
                         </span>
                         <span className="text-gray-600 w-12 text-right text-xs">
-                          {row.winRate.toFixed(1)}%
+                          {formatWinRate(row.winRate)}%
                         </span>
                         {row.teammateIsVerified ? (
                           <ChevronRight className="w-3 h-3 text-gray-700 group-hover:text-gray-500 transition-colors duration-100" />
@@ -993,14 +1012,21 @@ function StatCard({
   data,
   record,
   winRate,
+  placementInfo,
 }: {
   label: string;
   data: Array<{ name: string; value: number }>;
   record: string;
   winRate: number;
+  placementInfo?: {
+    playerName: string;
+    wins: number;
+    losses: number;
+    adjustedRate: number;
+  };
 }) {
   return (
-    <Card className="bg-transparent">
+    <Card className="bg-transparent relative">
       <CardHeader className="pb-2">
         <CardTitle className="text-xs font-medium text-gray-500">
           {label}
@@ -1014,6 +1040,66 @@ function StatCard({
           </p>
         </div>
       </CardContent>
+      {placementInfo ? (
+        <Dialog>
+          <DialogTrigger asChild>
+            <button
+              type="button"
+              className="absolute bottom-3 right-3 text-[11px] font-medium text-indigo-400 hover:text-indigo-300 bg-indigo-400/10 hover:bg-indigo-400/20 px-2.5 py-1 rounded-md transition-colors"
+            >
+              Win rate % adjusted
+            </button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogClose className="absolute right-3 top-3 text-gray-500 hover:text-gray-300 transition-colors">
+              <X className="h-4 w-4" />
+            </DialogClose>
+            <DialogHeader>
+              <DialogTitle>How Win Rate % Works</DialogTitle>
+              <DialogDescription>
+                Players need at least 5 drafts for a full win rate.
+                Until then, wins are divided by 5 instead of total games.
+              </DialogDescription>
+            </DialogHeader>
+            <div className="mt-3 space-y-3 text-sm text-gray-300">
+              <p className="text-[13px] text-gray-400">
+                Win Rate = Wins / (Total Games or 5, whichever is higher)
+              </p>
+              <div className="rounded-md bg-gray-800/50 px-3 py-2.5 space-y-1.5 text-xs tabular-nums">
+                <p className="text-gray-400 text-[11px] mb-1 truncate" title={placementInfo.playerName}>
+                  {placementInfo.playerName}
+                </p>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">{placementInfo.wins}-{placementInfo.losses} record</span>
+                  <span>{placementInfo.wins} / 5 = {formatWinRate(placementInfo.adjustedRate)}%</span>
+                </div>
+              </div>
+              <div className="rounded-md bg-gray-800/50 px-3 py-2.5 space-y-1.5 text-xs tabular-nums">
+                <p className="text-gray-400 text-[11px] mb-1">Under 5 drafts</p>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">2-0 record</span>
+                  <span>2 / 5 = 40%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">4-1 record</span>
+                  <span>4 / 5 = 80%</span>
+                </div>
+              </div>
+              <div className="rounded-md bg-gray-800/50 px-3 py-2.5 space-y-1.5 text-xs tabular-nums">
+                <p className="text-gray-400 text-[11px] mb-1">5+ drafts (normal)</p>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">7-3 record</span>
+                  <span>7 / 10 = 70%</span>
+                </div>
+                <div className="flex justify-between">
+                  <span className="text-gray-400">12-8 record</span>
+                  <span>12 / 20 = 60%</span>
+                </div>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      ) : null}
     </Card>
   );
 }
@@ -1047,7 +1133,7 @@ function MiniDonut({
       </ResponsiveContainer>
       <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
         <span className="text-lg font-semibold tabular-nums text-gray-100 leading-none">
-          {winRate.toFixed(1)}
+          {formatWinRate(winRate)}
         </span>
       </div>
     </div>
@@ -1077,7 +1163,7 @@ function BreakdownRow({
         indicatorClassName={barClass}
       />
       <span className="text-xs text-gray-500 tabular-nums w-12 text-right">
-        {stats.winRate.toFixed(1)}%
+        {formatWinRate(stats.winRate)}%
       </span>
     </div>
   );

--- a/src/server/draftLeaderboard.ts
+++ b/src/server/draftLeaderboard.ts
@@ -57,6 +57,17 @@ export type DraftLeaderboardRow = {
   captainWinRate: number;
 };
 
+const MIN_GAMES_FOR_PLACEMENT_WIN_RATE = 5;
+
+function toPlacementWinRatePercent(wins: number, losses: number): number {
+  const games = wins + losses;
+  const denominator = Math.max(games, MIN_GAMES_FOR_PLACEMENT_WIN_RATE);
+  if (denominator <= 0) {
+    return 0;
+  }
+  return Math.round((wins / denominator) * 1000) / 10;
+}
+
 function getConvexClient() {
   const url = process.env.NEXT_PUBLIC_CONVEX_URL;
   if (!url) {
@@ -162,7 +173,7 @@ export function aggregateDraftLeaderboardRows(
         wins: value.wins,
         losses: value.losses,
         games,
-        winRate: games > 0 ? Math.round((value.wins / games) * 1000) / 10 : 0,
+        winRate: toPlacementWinRatePercent(value.wins, value.losses),
         captainWins: value.captainWins,
         captainLosses: value.captainLosses,
         captainGames,

--- a/src/server/draftStats.ts
+++ b/src/server/draftStats.ts
@@ -172,6 +172,8 @@ type DraftIdentityContext = {
   userNameByClerkUserId: Map<string, string>;
 };
 
+const MIN_GAMES_FOR_PLACEMENT_WIN_RATE = 5;
+
 function toLeaderboardPlayerId(
   discordUserId: string,
   clerkByDiscordUserId: Map<string, string>
@@ -441,13 +443,18 @@ export function aggregateHeadToHeadRow(
   };
 }
 
-function computeWinRate(wins: number, losses: number): WinLossRecord {
+function computeWinRate(
+  wins: number,
+  losses: number,
+  minGamesFloor = 0
+): WinLossRecord {
   const games = wins + losses;
+  const denominator = Math.max(games, minGamesFloor);
   return {
     wins,
     losses,
     games,
-    winRate: games > 0 ? Math.round((wins / games) * 1000) / 10 : 0,
+    winRate: denominator > 0 ? Math.round((wins / denominator) * 1000) / 10 : 0,
   };
 }
 
@@ -855,7 +862,7 @@ export function aggregatePlayerDrilldown(
     playerName,
     profileName,
     avatarUrl,
-    overall: computeWinRate(wins, losses),
+    overall: computeWinRate(wins, losses, MIN_GAMES_FOR_PLACEMENT_WIN_RATE),
     captain: computeWinRate(captainWins, captainLosses),
     byRealm,
     byClass,


### PR DESCRIPTION
### Summary

- Ranks overall win rate using wins divided by the larger of total games or 5, so small samples (e.g. 1–0) do not dominate the leaderboard.
- Class-specific and other breakdown win rates are unchanged.
### UI

- Leaderboard (Win % sort): dimmed styling for under-5-draft rows, indigo pill with short copy before W/L, row tooltip, and animated “Learn more” next to the subtitle that opens the explainer modal.
- Player drilldown: “Win rate % adjusted” on the Overall card when under 5 drafts, with a modal that includes the player’s name and examples.
### Cleanup

- Removed unused games and rawRate from placementInfo on the drilldown stat card.