### PR TITLE
Draft history UI tweak + live draft auto-refresh

### DIFF
--- a/src/app/draft-history/DraftHistoryClient.tsx
+++ b/src/app/draft-history/DraftHistoryClient.tsx
@@ -614,14 +614,6 @@ export default function DraftHistoryClient({
                         <span className="text-gray-400">
                           {row.teamSize}v{row.teamSize}
                         </span>
-                        {autoBans.length > 0 ? (
-                          <>
-                            <span className="text-gray-700 select-none">&middot;</span>
-                            <span className="inline-flex items-center gap-1 rounded border border-gray-700/60 bg-gray-800/40 px-1.5 py-0.5 text-[10px] font-medium text-gray-400">
-                              Auto-banned &middot; {autoBans.length}
-                            </span>
-                          </>
-                        ) : null}
                         <span className="text-gray-700 select-none">&middot;</span>
                         <span className="inline-flex min-w-0 items-center gap-1.5 text-gray-500">
                           <User className="w-3 h-3 flex-shrink-0 text-gray-600" />

--- a/src/app/draft-history/DraftHistoryNavAutoRefresh.tsx
+++ b/src/app/draft-history/DraftHistoryNavAutoRefresh.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { useEffect } from "react";
+import { usePathname, useRouter } from "next/navigation";
+
+const REFRESH_INTERVAL_MS = 30000;
+
+export default function DraftHistoryNavAutoRefresh() {
+  const router = useRouter();
+  const pathname = usePathname() ?? "";
+
+  useEffect(() => {
+    const refreshIfNeeded = () => {
+      if (
+        pathname.startsWith("/draft-history/live") ||
+        document.visibilityState !== "visible"
+      ) {
+        return;
+      }
+      router.refresh();
+    };
+
+    const intervalId = setInterval(refreshIfNeeded, REFRESH_INTERVAL_MS);
+    const onVisibilityChange = () => {
+      refreshIfNeeded();
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [pathname, router]);
+
+  return null;
+}

--- a/src/app/draft-history/layout.tsx
+++ b/src/app/draft-history/layout.tsx
@@ -1,5 +1,6 @@
 import DraftHistoryNav from "./DraftHistoryNav";
 import { getLiveDraftCount } from "@/server/draftLive";
+import DraftHistoryNavAutoRefresh from "./DraftHistoryNavAutoRefresh";
 
 export const revalidate = 30;
 
@@ -13,6 +14,7 @@ export default async function DraftHistoryLayout({
   return (
     <div className="bg-gray-900 min-h-screen text-gray-300 py-8">
       <section className="max-w-3xl mx-auto px-6">
+        <DraftHistoryNavAutoRefresh />
         <DraftHistoryNav liveDraftCount={liveDraftCount} />
         {children}
       </section>

--- a/src/app/draft-history/live/LiveDraftsAutoRefresh.tsx
+++ b/src/app/draft-history/live/LiveDraftsAutoRefresh.tsx
@@ -1,0 +1,34 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+
+const REFRESH_INTERVAL_MS = 15000;
+
+export default function LiveDraftsAutoRefresh() {
+  const router = useRouter();
+
+  useEffect(() => {
+    const refreshIfVisible = () => {
+      if (document.visibilityState === "visible") {
+        router.refresh();
+      }
+    };
+
+    const intervalId = setInterval(refreshIfVisible, REFRESH_INTERVAL_MS);
+    const onVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        router.refresh();
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibilityChange);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibilityChange);
+    };
+  }, [router]);
+
+  return null;
+}

--- a/src/app/draft-history/live/page.tsx
+++ b/src/app/draft-history/live/page.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { User } from "lucide-react";
 import { getLiveDraftRows } from "@/server/draftLive";
+import LiveDraftsAutoRefresh from "./LiveDraftsAutoRefresh";
 
 export const revalidate = 15;
 
@@ -23,6 +24,7 @@ export default async function LiveDraftsPage() {
 
   return (
     <>
+      <LiveDraftsAutoRefresh />
       <div className="mb-6">
         <h1 className="text-xl font-semibold tracking-tight text-gray-100">Live Drafts</h1>
         <p className="mt-1 text-[13px] text-gray-500">


### PR DESCRIPTION
- Dropped the redundant "Auto-banned · N" chip in the card footer (the dedicated auto-ban section still shows the classes).
- Added lightweight polling so the Live drafts list and the Live tab indicator update without a manual refresh—only when the tab is visible, and the nav refresh skips the live page so we’re not double-refreshing there.