### PR TITLE
refactor: drop (site) route group; finish contribute + test/draft component colocation

### DIFF
--- a/src/app/contribute/_components/SupporterTiersShowcase.tsx
+++ b/src/app/contribute/_components/SupporterTiersShowcase.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import SupporterBadge from "@/components/support/SupporterBadge";
-import { SUPPORTER_TIER_PLANS } from "./_lib/supporterTierPlans";
+import { SUPPORTER_TIER_PLANS } from "../_lib/supporterTierPlans";
 
 export default function SupporterTiersShowcase() {
   return (

--- a/src/app/test/draft/_components/DraftTestPageClient.tsx
+++ b/src/app/test/draft/_components/DraftTestPageClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useMutation, useQuery } from "convex/react";
-import { api } from "../../../../convex/_generated/api";
+import { api } from "../../../../../convex/_generated/api";
 import { useState, useEffect, useMemo } from "react";
 import { Button } from "@/components/ui/button";
 import { cn } from "@/lib/utils";

--- a/src/app/test/draft/page.tsx
+++ b/src/app/test/draft/page.tsx
@@ -1,6 +1,6 @@
 import dynamic from "next/dynamic";
 
-const DraftTestPageClient = dynamic(() => import("./DraftTestPageClient"), {
+const DraftTestPageClient = dynamic(() => import("./_components/DraftTestPageClient"), {
   ssr: false,
 });
 


### PR DESCRIPTION
### Changes 
- Move SupporterTiersShowcase into src/app/contribute/_components and update the supporterTierPlans import.
- Move DraftTestPageClient into src/app/test/draft/_components, update page.tsx dynamic import, and fix the Convex api relative path after the extra directory level.
- Validation: lint, typecheck, feature tests, and production build.