### PR TITLE
- feat(billing): add PayPal subscriptions alongside Stripe

### DIFF
--- a/prisma/migrations/20260420120000_add_paypal_billing_provider/migration.sql
+++ b/prisma/migrations/20260420120000_add_paypal_billing_provider/migration.sql
@@ -1,0 +1,20 @@
+CREATE TYPE "BillingProvider" AS ENUM ('stripe', 'paypal');
+
+ALTER TABLE "User"
+ADD COLUMN "paypalPayerId" TEXT,
+ADD COLUMN "paypalSubscriptionId" TEXT,
+ADD COLUMN "subscriptionProvider" "BillingProvider";
+
+CREATE UNIQUE INDEX "User_paypalPayerId_key" ON "User"("paypalPayerId");
+CREATE UNIQUE INDEX "User_paypalSubscriptionId_key" ON "User"("paypalSubscriptionId");
+
+CREATE TABLE "BillingWebhookEvent" (
+    "id" SERIAL NOT NULL,
+    "provider" "BillingProvider" NOT NULL,
+    "externalEventId" TEXT NOT NULL,
+    "processedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    CONSTRAINT "BillingWebhookEvent_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "BillingWebhookEvent_provider_externalEventId_key"
+ON "BillingWebhookEvent"("provider", "externalEventId");

--- a/prisma/migrations/20260420170000_add_pending_paypal_plan_change/migration.sql
+++ b/prisma/migrations/20260420170000_add_pending_paypal_plan_change/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User"
+ADD COLUMN "pendingSubscriptionPriceId" TEXT;

--- a/prisma/migrations/20260420213000_backfill_subscription_provider_for_legacy_users/migration.sql
+++ b/prisma/migrations/20260420213000_backfill_subscription_provider_for_legacy_users/migration.sql
@@ -1,0 +1,9 @@
+UPDATE "User"
+SET "subscriptionProvider" = 'stripe'
+WHERE "subscriptionProvider" IS NULL
+  AND ("stripeSubscriptionId" IS NOT NULL OR "stripeCustomerId" IS NOT NULL);
+
+UPDATE "User"
+SET "subscriptionProvider" = 'paypal'
+WHERE "subscriptionProvider" IS NULL
+  AND ("paypalSubscriptionId" IS NOT NULL OR "paypalPayerId" IS NOT NULL);

--- a/prisma/migrations/20260421003000_add_subscription_provider_updated_at/migration.sql
+++ b/prisma/migrations/20260421003000_add_subscription_provider_updated_at/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User"
+ADD COLUMN "subscriptionProviderUpdatedAt" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,6 +8,11 @@ datasource db {
   directUrl = env("POSTGRES_URL_NON_POOLING")
 }
 
+enum BillingProvider {
+  stripe
+  paypal
+}
+
 model Account {
   id                 Int     @id @default(autoincrement()) @unique
   userId             Int?     @unique
@@ -34,8 +39,13 @@ model User {
   preferredCharacterListLayout String @default("table")
   stripeCustomerId String?         @unique
   stripeSubscriptionId String?     @unique
+  paypalPayerId String?            @unique
+  paypalSubscriptionId String?     @unique
+  subscriptionProvider BillingProvider?
+  subscriptionProviderUpdatedAt DateTime?
   subscriptionStatus String?
   subscriptionPriceId String?
+  pendingSubscriptionPriceId String?
   subscriptionCurrentPeriodEnd DateTime?
   subscriptionCancelAtPeriodEnd Boolean @default(false)
   account        Account?
@@ -48,6 +58,15 @@ model User {
 model StripeWebhookEvent {
   id          String   @id
   processedAt DateTime @default(now())
+}
+
+model BillingWebhookEvent {
+  id              Int             @id @default(autoincrement())
+  provider        BillingProvider
+  externalEventId String
+  processedAt     DateTime        @default(now())
+
+  @@unique([provider, externalEventId])
 }
 
 model Character {

--- a/src/app/_components/SupportPromptModal.tsx
+++ b/src/app/_components/SupportPromptModal.tsx
@@ -590,7 +590,7 @@ export default function SupportPromptModal({
           setIsOpen(true);
         }}
       >
-        <DialogContent className="max-w-md border-gray-800 bg-gray-900 p-0 gap-0 overflow-hidden max-h-[90dvh] overflow-y-auto overscroll-contain">
+        <DialogContent className="max-w-[calc(100vw-2rem)] sm:max-w-lg border-gray-800 bg-gray-900 p-0 gap-0 overflow-hidden max-h-[90dvh] overflow-y-auto overscroll-contain">
           <div className="px-4 sm:px-5 pt-4 sm:pt-5 pb-3 sm:pb-4">
             <DialogTitle className="text-base font-semibold text-white">
               Help keep divoxutils running
@@ -602,7 +602,7 @@ export default function SupportPromptModal({
           </div>
 
           <div className="mx-4 sm:mx-5 rounded-lg border border-gray-800 bg-gray-800/20 p-3 sm:p-4 space-y-3">
-            <h3 className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Cost Breakdown</h3>
+            <h3 className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Cost Breakdown</h3>
             <dl className="grid grid-cols-[1fr_auto] gap-x-3 sm:gap-x-6 gap-y-1.5 sm:gap-y-2 text-sm">
               <dt className="text-gray-300">Cloud hosting and runtime infrastructure</dt>
               <dd className="text-gray-200 tabular-nums text-right shrink-0">$20 / mo</dd>
@@ -619,7 +619,7 @@ export default function SupportPromptModal({
             </dl>
             <div className="h-px bg-gray-800" />
             <div className="space-y-2 text-sm">
-              <p className="text-xs font-semibold text-gray-500 uppercase tracking-wider">Total costs</p>
+              <p className="text-xs font-semibold text-gray-400 uppercase tracking-wider">Total costs</p>
               <div className="flex items-center justify-between text-gray-300">
                 <span>Monthly estimate</span>
                 <span className="text-white font-medium">~$61 - $121+</span>
@@ -632,19 +632,13 @@ export default function SupportPromptModal({
           </div>
 
           {paypalEnabled && (
-            <div className="mx-4 sm:mx-5 mt-3 space-y-1.5">
-              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Payment method
-              </p>
+            <div className="mx-4 sm:mx-5 mt-3">
               <PaymentProviderToggle
                 value={provider}
                 onChange={setProvider}
                 disabled={loadingTier !== null}
                 size="sm"
               />
-              <p className="text-[11px] text-gray-500">
-                Secure checkout via Stripe or PayPal. Payment details are handled by the provider and never stored by divoxutils.
-              </p>
             </div>
           )}
 
@@ -687,7 +681,7 @@ export default function SupportPromptModal({
             </div>
           )}
 
-          {(!isSignedIn || debug) && (
+          {!isSignedIn && (
             <div className="mx-4 sm:mx-5 mt-2">
               <button
                 type="button"
@@ -704,7 +698,7 @@ export default function SupportPromptModal({
           )}
 
           <div className="px-4 sm:px-5 pt-3 pb-4 sm:pb-5 flex items-center justify-between gap-3">
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-gray-400">
               Any active tier removes this reminder.
             </p>
             <button

--- a/src/app/_components/SupportPromptModal.tsx
+++ b/src/app/_components/SupportPromptModal.tsx
@@ -8,6 +8,9 @@ import { Dialog, DialogContent, DialogDescription, DialogTitle } from "@/compone
 import SupporterBadge from "@/components/support/SupporterBadge";
 import { getWindowedImpressions, resolveCadence } from "@/components/support/supportPromptCadence";
 import { SUPPORT_PROMPT_TIER_PLANS } from "@/components/support/supportPromptTierPlans";
+import PaymentProviderToggle, {
+  type PaymentProvider,
+} from "@/components/support/PaymentProviderToggle";
 import {
   isKnownExemptActive,
   shouldClearKnownExempt,
@@ -19,6 +22,7 @@ const KNOWN_EXEMPT_UNTIL_KEY = "divoxutils_support_prompt_known_exempt_until_v1"
 const KNOWN_EXEMPT_PERSIST_UNTIL = Number.MAX_SAFE_INTEGER;
 const CLOSE_LOCK_SUFFIX = "_close_lock_until_v1";
 const PENDING_TIER_KEY = "divoxutils_support_prompt_pending_tier_v1";
+const PENDING_PROVIDER_KEY = "divoxutils_support_prompt_pending_provider_v1";
 const LOCK_ALLOWED_PATH_PREFIXES = ["/contribute", "/billing", "/sign-in", "/sign-up"];
 
 type PromptHistory = {
@@ -32,6 +36,7 @@ type SupportPromptModalProps = {
   ignorePathRules?: boolean;
   isSupporter?: boolean;
   isAdmin?: boolean;
+  paypalEnabled?: boolean;
 };
 
 function defaultHistory(): PromptHistory {
@@ -164,11 +169,36 @@ function writePendingTier(tier: 1 | 2 | 3 | null) {
   }
 }
 
+function readPendingProvider(): PaymentProvider {
+  if (typeof window === "undefined") return "stripe";
+  try {
+    const raw = window.localStorage.getItem(PENDING_PROVIDER_KEY);
+    if (raw === "paypal") return "paypal";
+    return "stripe";
+  } catch {
+    return "stripe";
+  }
+}
+
+function writePendingProvider(provider: PaymentProvider | null) {
+  if (typeof window === "undefined") return;
+  try {
+    if (!provider) {
+      window.localStorage.removeItem(PENDING_PROVIDER_KEY);
+      return;
+    }
+    window.localStorage.setItem(PENDING_PROVIDER_KEY, provider);
+  } catch {
+    return;
+  }
+}
+
 export default function SupportPromptModal({
   debug = false,
   ignorePathRules = false,
   isSupporter = false,
   isAdmin = false,
+  paypalEnabled = false,
 }: SupportPromptModalProps) {
   const checkoutErrorId = useId();
   const { isLoaded, isSignedIn } = useAuth();
@@ -182,6 +212,7 @@ export default function SupportPromptModal({
   const [closeLockUntil, setCloseLockUntil] = useState<number | null>(null);
   const [loadingTier, setLoadingTier] = useState<number | null>(null);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  const [provider, setProvider] = useState<PaymentProvider>("stripe");
   const [history, setHistory] = useState<PromptHistory>(defaultHistory());
   const [isKnownExempt, setIsKnownExempt] = useState(false);
   const cadence = useMemo(() => resolveCadence(Boolean(isSignedIn)), [isSignedIn]);
@@ -223,7 +254,11 @@ export default function SupportPromptModal({
   });
 
   const startCheckout = useCallback(
-    async (tier: 1 | 2 | 3, source: "modal" | "sign_in_return") => {
+    async (
+      tier: 1 | 2 | 3,
+      source: "modal" | "sign_in_return",
+      selectedProvider: PaymentProvider
+    ) => {
       setCheckoutError(null);
       setLoadingTier(tier);
       const current = readHistory(cadence.storageKey);
@@ -234,9 +269,17 @@ export default function SupportPromptModal({
       };
       writeHistory(cadence.storageKey, updated);
       setHistory(updated);
-      trackSupportPromptEvent("support_modal_clicked_subscribe", { source, tier });
+      trackSupportPromptEvent("support_modal_clicked_subscribe", {
+        source,
+        tier,
+        provider: selectedProvider,
+      });
       try {
-        const response = await fetch("/api/billing/create-checkout-session", {
+        const endpoint =
+          selectedProvider === "paypal"
+            ? "/api/billing/create-paypal-subscription"
+            : "/api/billing/create-checkout-session";
+        const response = await fetch(endpoint, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ tier }),
@@ -385,14 +428,27 @@ export default function SupportPromptModal({
     if (!isLoaded || !isSignedIn) return;
     if (isSupporter || isAdmin) {
       writePendingTier(null);
+      writePendingProvider(null);
       return;
     }
     if (loadingTier !== null) return;
     const pendingTier = readPendingTier();
     if (!pendingTier) return;
+    const pendingProvider = readPendingProvider();
+    const resolvedProvider: PaymentProvider =
+      pendingProvider === "paypal" && paypalEnabled ? "paypal" : "stripe";
     writePendingTier(null);
-    void startCheckout(pendingTier, "sign_in_return");
-  }, [isLoaded, isSignedIn, isSupporter, isAdmin, loadingTier, startCheckout]);
+    writePendingProvider(null);
+    void startCheckout(pendingTier, "sign_in_return", resolvedProvider);
+  }, [
+    isLoaded,
+    isSignedIn,
+    isSupporter,
+    isAdmin,
+    loadingTier,
+    paypalEnabled,
+    startCheckout,
+  ]);
 
   useEffect(() => {
     if (isPathEligible) return;
@@ -450,13 +506,15 @@ export default function SupportPromptModal({
 
   const subscribeNow = async (tier: 1 | 2 | 3) => {
     setCheckoutError(null);
+    const selectedProvider: PaymentProvider = paypalEnabled ? provider : "stripe";
     if (!isSignedIn) {
       writePendingTier(tier);
+      writePendingProvider(selectedProvider);
       const redirectPath = pathname || "/";
       router.push(`/sign-in?redirect_url=${encodeURIComponent(redirectPath)}`);
       return;
     }
-    await startCheckout(tier, "modal");
+    await startCheckout(tier, "modal", selectedProvider);
   };
 
   const resetHistory = () => {
@@ -464,6 +522,7 @@ export default function SupportPromptModal({
     writeHistory(cadence.storageKey, fresh);
     writeCloseLockUntil(cadence.storageKey, null);
     writePendingTier(null);
+    writePendingProvider(null);
     setHistory(fresh);
     setIsOpen(false);
     setCanClose(false);
@@ -571,6 +630,23 @@ export default function SupportPromptModal({
               </div>
             </div>
           </div>
+
+          {paypalEnabled && (
+            <div className="mx-4 sm:mx-5 mt-3 space-y-1.5">
+              <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Payment method
+              </p>
+              <PaymentProviderToggle
+                value={provider}
+                onChange={setProvider}
+                disabled={loadingTier !== null}
+                size="sm"
+              />
+              <p className="text-[11px] text-gray-500">
+                Secure checkout via Stripe or PayPal. Payment details are handled by the provider and never stored by divoxutils.
+              </p>
+            </div>
+          )}
 
           <div className="mx-4 sm:mx-5 mt-3 space-y-2">
             {SUPPORT_PROMPT_TIER_PLANS.map((plan) => (

--- a/src/app/api/billing/cancel-paypal-subscription/route.ts
+++ b/src/app/api/billing/cancel-paypal-subscription/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import prisma from "../../../../../prisma/prismaClient";
+import { cancelPayPalSubscription, isPayPalSubscriptionsEnabled } from "@/server/billing/paypal";
+import { cancelPayPalSubscriptionHandler } from "@/server/api/billingRouteHandlers";
+
+const methodNotAllowed = () => NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+
+const postHandler = cancelPayPalSubscriptionHandler({
+  getAuthUserId: async () => (await auth()).userId,
+  isPayPalEnabled: isPayPalSubscriptionsEnabled,
+  findUserByClerkId: (clerkUserId) =>
+    prisma.user.findUnique({
+      where: { clerkUserId },
+      select: {
+        clerkUserId: true,
+        subscriptionProvider: true,
+        paypalSubscriptionId: true,
+      },
+    }),
+  cancelPayPalSubscription: ({ paypalSubscriptionId, reason }) =>
+    cancelPayPalSubscription(paypalSubscriptionId, reason),
+  markPayPalSubscriptionCancelAtPeriodEnd: async ({ clerkUserId }) => {
+    await prisma.user.update({
+      where: { clerkUserId },
+      data: {
+        subscriptionCancelAtPeriodEnd: true,
+        pendingSubscriptionPriceId: null,
+      },
+    });
+  },
+});
+
+export async function POST(request: Request) {
+  const result = await postHandler({
+    method: request.method,
+    body: null,
+    headers: request.headers,
+  });
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function GET() {
+  return methodNotAllowed();
+}
+
+export async function PUT() {
+  return methodNotAllowed();
+}
+
+export async function PATCH() {
+  return methodNotAllowed();
+}
+
+export async function DELETE() {
+  return methodNotAllowed();
+}

--- a/src/app/api/billing/change-paypal-plan/route.ts
+++ b/src/app/api/billing/change-paypal-plan/route.ts
@@ -24,8 +24,8 @@ const postHandler = changePayPalPlanHandler({
         paypalSubscriptionId: true,
       },
     }),
-  revisePayPalSubscriptionPlan: ({ paypalSubscriptionId, planId }) =>
-    revisePayPalSubscriptionPlan({ paypalSubscriptionId, planId }),
+  revisePayPalSubscriptionPlan: ({ paypalSubscriptionId, planId, origin }) =>
+    revisePayPalSubscriptionPlan({ paypalSubscriptionId, planId, origin }),
   updatePendingSubscriptionPriceId: async ({ clerkUserId, pendingSubscriptionPriceId }) => {
     await prisma.user.update({
       where: { clerkUserId },

--- a/src/app/api/billing/change-paypal-plan/route.ts
+++ b/src/app/api/billing/change-paypal-plan/route.ts
@@ -1,0 +1,65 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import prisma from "../../../../../prisma/prismaClient";
+import {
+  getPayPalPlanMap,
+  isPayPalSubscriptionsEnabled,
+  revisePayPalSubscriptionPlan,
+} from "@/server/billing/paypal";
+import { changePayPalPlanHandler } from "@/server/api/billingRouteHandlers";
+
+const postHandler = changePayPalPlanHandler({
+  getAuthUserId: async () => (await auth()).userId,
+  getPlanMap: getPayPalPlanMap,
+  isPayPalEnabled: isPayPalSubscriptionsEnabled,
+  findUserByClerkId: (clerkUserId) =>
+    prisma.user.findUnique({
+      where: { clerkUserId },
+      select: {
+        clerkUserId: true,
+        subscriptionProvider: true,
+        subscriptionStatus: true,
+        subscriptionPriceId: true,
+        pendingSubscriptionPriceId: true,
+        paypalSubscriptionId: true,
+      },
+    }),
+  revisePayPalSubscriptionPlan: ({ paypalSubscriptionId, planId }) =>
+    revisePayPalSubscriptionPlan({ paypalSubscriptionId, planId }),
+  updatePendingSubscriptionPriceId: async ({ clerkUserId, pendingSubscriptionPriceId }) => {
+    await prisma.user.update({
+      where: { clerkUserId },
+      data: {
+        pendingSubscriptionPriceId,
+      },
+    });
+  },
+});
+
+const methodNotAllowed = () => NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const result = await postHandler({
+    method: request.method,
+    body,
+    headers: request.headers,
+  });
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function GET() {
+  return methodNotAllowed();
+}
+
+export async function PUT() {
+  return methodNotAllowed();
+}
+
+export async function PATCH() {
+  return methodNotAllowed();
+}
+
+export async function DELETE() {
+  return methodNotAllowed();
+}

--- a/src/app/api/billing/create-paypal-subscription/route.ts
+++ b/src/app/api/billing/create-paypal-subscription/route.ts
@@ -1,0 +1,78 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import prisma from "../../../../../prisma/prismaClient";
+import {
+  createPayPalSubscription,
+  getPayPalPlanMap,
+  isPayPalSubscriptionsEnabled,
+} from "@/server/billing/paypal";
+import { createPayPalSubscriptionHandler } from "@/server/api/billingRouteHandlers";
+
+const postHandler = createPayPalSubscriptionHandler({
+  getAuthUserId: async () => (await auth()).userId,
+  getPlanMap: getPayPalPlanMap,
+  isPayPalEnabled: isPayPalSubscriptionsEnabled,
+  findUserByClerkId: (clerkUserId) =>
+    prisma.user.findUnique({
+      where: { clerkUserId },
+      select: { clerkUserId: true, subscriptionStatus: true },
+    }),
+  createPayPalSubscription: ({ planId, clerkUserId, tier, origin }) =>
+    createPayPalSubscription({
+      planId,
+      clerkUserId,
+      tier,
+      origin,
+    }),
+  recordPayPalSubscription: async ({
+    clerkUserId,
+    paypalSubscriptionId,
+    paypalPayerId,
+    subscriptionStatus,
+    subscriptionPriceId,
+  }) => {
+    await prisma.user.update({
+      where: { clerkUserId },
+      data: {
+        subscriptionProvider: "paypal",
+        subscriptionProviderUpdatedAt: new Date(),
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        paypalSubscriptionId,
+        paypalPayerId,
+        subscriptionStatus,
+        subscriptionPriceId,
+        pendingSubscriptionPriceId: null,
+        subscriptionCancelAtPeriodEnd: false,
+      },
+    });
+  },
+});
+
+const methodNotAllowed = () => NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+
+export async function POST(request: Request) {
+  const body = await request.json().catch(() => null);
+  const result = await postHandler({
+    method: request.method,
+    body,
+    headers: request.headers,
+  });
+  return NextResponse.json(result.body, { status: result.status });
+}
+
+export async function GET() {
+  return methodNotAllowed();
+}
+
+export async function PUT() {
+  return methodNotAllowed();
+}
+
+export async function PATCH() {
+  return methodNotAllowed();
+}
+
+export async function DELETE() {
+  return methodNotAllowed();
+}

--- a/src/app/api/billing/create-portal-session/route.ts
+++ b/src/app/api/billing/create-portal-session/route.ts
@@ -9,8 +9,10 @@ const postHandler = createPortalSessionHandler({
   findCustomerIdByClerkUserId: async (clerkUserId) => {
     const user = await prisma.user.findUnique({
       where: { clerkUserId },
-      select: { stripeCustomerId: true },
+      select: { stripeCustomerId: true, subscriptionProvider: true },
     });
+    if (!user?.stripeCustomerId) return null;
+    if (user.subscriptionProvider && user.subscriptionProvider !== "stripe") return null;
     return user?.stripeCustomerId ?? null;
   },
   createPortalSession: ({ customerId, returnUrl }) =>

--- a/src/app/api/billing/reconcile-subscriptions/route.ts
+++ b/src/app/api/billing/reconcile-subscriptions/route.ts
@@ -5,6 +5,16 @@ import { fetchPayPalSubscription, getPayPalPlanMap, isPayPalSubscriptionsEnabled
 import { extractRecurringPriceId, getStripeClient, getStripePriceMap, getTierFromPriceId, shouldGrantSupporterBadge } from "@/server/billing/stripe";
 import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
 
+const hasFutureGraceAccess = (params: {
+  cancelAtPeriodEnd: boolean;
+  periodEnd: Date | null;
+  nowMs?: number;
+}): boolean => {
+  if (!params.cancelAtPeriodEnd || !params.periodEnd) return false;
+  const nowMs = params.nowMs ?? Date.now();
+  return params.periodEnd.getTime() > nowMs;
+};
+
 const run = async (method: string, request: NextRequest) => {
   if (!hasValidCronAuthorization(request.headers.get("authorization"), process.env.CRON_SECRET)) {
     return unauthorizedCronResponse();
@@ -127,7 +137,12 @@ const run = async (method: string, request: NextRequest) => {
             ? null
             : user.pendingSubscriptionPriceId;
         const supporterTier =
-          status && isActiveSubscriptionStatus(status)
+          (status && isActiveSubscriptionStatus(status)) ||
+          hasFutureGraceAccess({
+            cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+            periodEnd,
+            nowMs: now,
+          })
             ? getTierFromPriceId(nextSubscriptionPriceId, paypalPlanMap)
             : 0;
         const changed =

--- a/src/app/api/billing/reconcile-subscriptions/route.ts
+++ b/src/app/api/billing/reconcile-subscriptions/route.ts
@@ -1,0 +1,179 @@
+import { NextRequest, NextResponse } from "next/server";
+import prisma from "../../../../../prisma/prismaClient";
+import { hasValidCronAuthorization, postMethodNotAllowedResponse, unauthorizedCronResponse } from "@/server/api/cronAuth";
+import { fetchPayPalSubscription, getPayPalPlanMap, isPayPalSubscriptionsEnabled } from "@/server/billing/paypal";
+import { extractRecurringPriceId, getStripeClient, getStripePriceMap, getTierFromPriceId, shouldGrantSupporterBadge } from "@/server/billing/stripe";
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
+
+const run = async (method: string, request: NextRequest) => {
+  if (!hasValidCronAuthorization(request.headers.get("authorization"), process.env.CRON_SECRET)) {
+    return unauthorizedCronResponse();
+  }
+
+  if (method !== "POST") {
+    return postMethodNotAllowedResponse(method);
+  }
+
+  const users = await prisma.user.findMany({
+    where: {
+      OR: [
+        { subscriptionProvider: { in: ["stripe", "paypal"] } },
+        {
+          subscriptionProvider: null,
+          OR: [
+            { stripeSubscriptionId: { not: null } },
+            { stripeCustomerId: { not: null } },
+            { paypalSubscriptionId: { not: null } },
+            { paypalPayerId: { not: null } },
+          ],
+        },
+      ],
+    },
+    select: {
+      clerkUserId: true,
+      subscriptionProvider: true,
+      subscriptionStatus: true,
+      subscriptionPriceId: true,
+      pendingSubscriptionPriceId: true,
+      subscriptionCancelAtPeriodEnd: true,
+      subscriptionCurrentPeriodEnd: true,
+      stripeCustomerId: true,
+      stripeSubscriptionId: true,
+      paypalSubscriptionId: true,
+      paypalPayerId: true,
+      supporterTier: true,
+    },
+    take: 500,
+  });
+
+  const stripePriceMap = getStripePriceMap();
+  const paypalPlanMap = isPayPalSubscriptionsEnabled() ? getPayPalPlanMap() : null;
+  let checked = 0;
+  let updated = 0;
+  const errors: string[] = [];
+
+  for (const user of users) {
+    checked += 1;
+    try {
+      const provider =
+        user.subscriptionProvider ??
+        (user.paypalSubscriptionId
+          ? "paypal"
+          : user.stripeSubscriptionId || user.stripeCustomerId
+            ? "stripe"
+            : null);
+
+      if (provider === "stripe" && user.stripeSubscriptionId) {
+        const subscription = await getStripeClient().subscriptions.retrieve(user.stripeSubscriptionId, {
+          expand: ["items.data.price"],
+        });
+        const priceId = extractRecurringPriceId(subscription);
+        const status = subscription.status;
+        const periodEnd =
+          typeof (subscription as unknown as { current_period_end?: number }).current_period_end ===
+          "number"
+            ? new Date(
+                ((subscription as unknown as { current_period_end?: number }).current_period_end ?? 0) *
+                  1000
+              )
+            : user.subscriptionCurrentPeriodEnd;
+        const cancelAtPeriodEnd = Boolean(subscription.cancel_at_period_end || subscription.cancel_at);
+        const supporterTier = shouldGrantSupporterBadge(status)
+          ? getTierFromPriceId(priceId, stripePriceMap)
+          : 0;
+        const changed =
+          user.subscriptionProvider !== provider ||
+          user.subscriptionStatus !== status ||
+          user.subscriptionPriceId !== priceId ||
+          user.subscriptionCancelAtPeriodEnd !== cancelAtPeriodEnd ||
+          user.supporterTier !== supporterTier ||
+          (periodEnd?.toISOString() ?? null) !== (user.subscriptionCurrentPeriodEnd?.toISOString() ?? null);
+        if (changed) {
+          await prisma.user.update({
+            where: { clerkUserId: user.clerkUserId },
+            data: {
+              subscriptionProvider: provider,
+              subscriptionProviderUpdatedAt:
+                user.subscriptionProvider !== provider ? new Date() : undefined,
+              subscriptionStatus: status,
+              subscriptionPriceId: priceId,
+              subscriptionCancelAtPeriodEnd: cancelAtPeriodEnd,
+              subscriptionCurrentPeriodEnd: periodEnd,
+              supporterTier,
+            },
+          });
+          updated += 1;
+        }
+      }
+
+      if (provider === "paypal" && paypalPlanMap && user.paypalSubscriptionId) {
+        const subscription = await fetchPayPalSubscription(user.paypalSubscriptionId);
+        const status = subscription.status;
+        const periodEnd = subscription.nextBillingTime
+          ? new Date(subscription.nextBillingTime)
+          : user.subscriptionCurrentPeriodEnd;
+        const now = Date.now();
+        const currentPeriodEndMs = user.subscriptionCurrentPeriodEnd?.getTime() ?? null;
+        const shouldPromotePendingPrice =
+          Boolean(user.pendingSubscriptionPriceId) &&
+          subscription.planId === user.pendingSubscriptionPriceId &&
+          (currentPeriodEndMs === null || currentPeriodEndMs <= now);
+        const nextSubscriptionPriceId =
+          user.pendingSubscriptionPriceId && !shouldPromotePendingPrice
+            ? user.subscriptionPriceId
+            : subscription.planId;
+        const nextPendingSubscriptionPriceId =
+          shouldPromotePendingPrice || !isActiveSubscriptionStatus(status)
+            ? null
+            : user.pendingSubscriptionPriceId;
+        const supporterTier =
+          status && isActiveSubscriptionStatus(status)
+            ? getTierFromPriceId(nextSubscriptionPriceId, paypalPlanMap)
+            : 0;
+        const changed =
+          user.subscriptionProvider !== provider ||
+          user.subscriptionStatus !== status ||
+          user.subscriptionPriceId !== nextSubscriptionPriceId ||
+          user.pendingSubscriptionPriceId !== nextPendingSubscriptionPriceId ||
+          user.subscriptionCancelAtPeriodEnd !== subscription.cancelAtPeriodEnd ||
+          user.supporterTier !== supporterTier ||
+          user.paypalPayerId !== subscription.payerId ||
+          (periodEnd?.toISOString() ?? null) !== (user.subscriptionCurrentPeriodEnd?.toISOString() ?? null);
+        if (changed) {
+          await prisma.user.update({
+            where: { clerkUserId: user.clerkUserId },
+            data: {
+              subscriptionProvider: provider,
+              subscriptionProviderUpdatedAt:
+                user.subscriptionProvider !== provider ? new Date() : undefined,
+              subscriptionStatus: status,
+              subscriptionPriceId: nextSubscriptionPriceId,
+              pendingSubscriptionPriceId: nextPendingSubscriptionPriceId,
+              subscriptionCancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+              subscriptionCurrentPeriodEnd: periodEnd,
+              paypalPayerId: subscription.payerId,
+              supporterTier,
+            },
+          });
+          updated += 1;
+        }
+      }
+    } catch {
+      errors.push(user.clerkUserId);
+    }
+  }
+
+  return NextResponse.json({
+    checked,
+    updated,
+    errors,
+  });
+};
+
+export const POST = async (request: NextRequest) => run("POST", request);
+export const GET = async (request: NextRequest) => run("GET", request);
+export const PUT = async (request: NextRequest) => run("PUT", request);
+export const PATCH = async (request: NextRequest) => run("PATCH", request);
+export const DELETE = async (request: NextRequest) => run("DELETE", request);
+export const OPTIONS = async (request: NextRequest) => run("OPTIONS", request);
+export const HEAD = async (request: NextRequest) => run("HEAD", request);

--- a/src/app/api/paypal/webhook/route.ts
+++ b/src/app/api/paypal/webhook/route.ts
@@ -1,29 +1,19 @@
 import { NextResponse } from "next/server";
 import { Prisma } from "@prisma/client";
 import prisma from "../../../../../prisma/prismaClient";
-import {
-  extractRecurringPriceId,
-  getStripeClient,
-  getStripePriceMap,
-  getStripeWebhookSecret,
-  getTierFromPriceId,
-  shouldGrantSupporterBadge,
-} from "@/server/billing/stripe";
-import { createStripeWebhookHandler } from "@/server/api/stripeWebhookRouteHandler";
+import { getPayPalPlanMap, verifyPayPalWebhook } from "@/server/billing/paypal";
+import { shouldGrantSupporterBadge } from "@/server/billing/stripe";
+import { createPayPalWebhookHandler } from "@/server/api/paypalWebhookRouteHandler";
 
 export const runtime = "nodejs";
 
-const postHandler = createStripeWebhookHandler({
-  getWebhookSecret: getStripeWebhookSecret,
-  constructEvent: (rawBody, signature, secret) =>
-    getStripeClient().webhooks.constructEvent(rawBody, signature, secret),
-  getPriceMap: getStripePriceMap,
-  markEventProcessed: async (eventId) => {
+const postHandler = createPayPalWebhookHandler({
+  markEventProcessed: async (externalEventId) => {
     try {
       await prisma.billingWebhookEvent.create({
         data: {
-          provider: "stripe",
-          externalEventId: eventId,
+          provider: "paypal",
+          externalEventId,
         },
       });
       return true;
@@ -37,14 +27,17 @@ const postHandler = createStripeWebhookHandler({
       throw error;
     }
   },
-  unmarkEventProcessed: async (eventId) => {
+  unmarkEventProcessed: async (externalEventId) => {
     await prisma.billingWebhookEvent.deleteMany({
       where: {
-        provider: "stripe",
-        externalEventId: eventId,
+        provider: "paypal",
+        externalEventId,
       },
     });
   },
+  verifyWebhook: (params) => verifyPayPalWebhook(params),
+  getPlanMap: getPayPalPlanMap,
+  shouldGrantSupporterBadge,
   findUserByClerkUserId: (clerkUserId) =>
     prisma.user.findUnique({
       where: { clerkUserId },
@@ -54,39 +47,57 @@ const postHandler = createStripeWebhookHandler({
         subscriptionProviderUpdatedAt: true,
         stripeSubscriptionId: true,
         paypalSubscriptionId: true,
+        subscriptionPriceId: true,
+        pendingSubscriptionPriceId: true,
+        subscriptionCurrentPeriodEnd: true,
       },
     }),
-  findUserByStripeCustomerId: (stripeCustomerId) =>
+  findUserByPayPalSubscriptionId: (paypalSubscriptionId) =>
     prisma.user.findFirst({
-      where: { stripeCustomerId },
+      where: { paypalSubscriptionId },
       select: {
         clerkUserId: true,
         subscriptionProvider: true,
         subscriptionProviderUpdatedAt: true,
         stripeSubscriptionId: true,
         paypalSubscriptionId: true,
+        subscriptionPriceId: true,
+        pendingSubscriptionPriceId: true,
+        subscriptionCurrentPeriodEnd: true,
       },
     }),
-  updateUserSubscription: async (clerkUserId, data) => {
-    await prisma.user.update({
+  findUserByPayPalPayerId: (paypalPayerId) =>
+    prisma.user.findFirst({
+      where: { paypalPayerId },
+      select: {
+        clerkUserId: true,
+        subscriptionProvider: true,
+        subscriptionProviderUpdatedAt: true,
+        stripeSubscriptionId: true,
+        paypalSubscriptionId: true,
+        subscriptionPriceId: true,
+        pendingSubscriptionPriceId: true,
+        subscriptionCurrentPeriodEnd: true,
+      },
+    }),
+  updateUserSubscription: (clerkUserId, data) =>
+    prisma.user.update({
       where: { clerkUserId },
       data,
-    });
-  },
-  extractRecurringPriceId,
-  getTierFromPriceId,
-  shouldGrantSupporterBadge,
+    }).then(() => {}),
 });
 
 const methodNotAllowed = () => NextResponse.json({ error: "Method not allowed" }, { status: 405 });
 
 const runPost = async (request: Request) => {
-  const rawBody = Buffer.from(await request.arrayBuffer());
-  const signature = request.headers.get("stripe-signature");
+  const body = (await request.json().catch(() => null)) as Record<string, unknown> | null;
+  if (!body) {
+    return NextResponse.json({ error: "Invalid PayPal webhook payload." }, { status: 400 });
+  }
   const result = await postHandler({
     method: request.method,
-    signature,
-    rawBody,
+    headers: request.headers,
+    body,
   });
   return NextResponse.json(result.body, { status: result.status });
 };

--- a/src/app/billing/_components/BillingClient.tsx
+++ b/src/app/billing/_components/BillingClient.tsx
@@ -100,6 +100,10 @@ export default function BillingClient({
   const isActive = isActiveSupportSubscriptionStatus(subscription?.status);
   const hasGraceAccess =
     Boolean(subscription?.cancelAtPeriodEnd) && isFutureDate(subscription?.currentPeriodEnd ?? null);
+  const hasManageablePayPalSubscription =
+    subscription?.provider === "paypal" &&
+    subscription?.hasPayPalSubscription &&
+    (isActive || hasGraceAccess);
   const showsAccessUntilState = isActive || hasGraceAccess;
   const shouldShowSyncHint = checkoutStatus === "success" || switchStatus === "scheduled";
   const syncRefreshKey = useMemo(() => {
@@ -149,6 +153,18 @@ export default function BillingClient({
         return;
       }
       writeTrackedCheckoutSessionIds(appendTrackedCheckoutSessionId(trackedSessionIds, checkoutSessionId));
+    } else {
+      if (typeof window !== "undefined") {
+        const fallbackTrackedKey = "divoxutils_billing_success_no_session_tracked_v1";
+        try {
+          if (window.sessionStorage.getItem(fallbackTrackedKey) === "1") {
+            hasTrackedSubscribeSuccess.current = true;
+            return;
+          }
+          window.sessionStorage.setItem(fallbackTrackedKey, "1");
+        } catch {
+        }
+      }
     }
     hasTrackedSubscribeSuccess.current = true;
     track("support_subscribe_success", {
@@ -337,7 +353,7 @@ export default function BillingClient({
         )}
       </div>
 
-      {isActive && subscription?.hasStripeCustomer ? (
+      {subscription?.provider === "stripe" && isActive && subscription?.hasStripeCustomer ? (
         <div className="space-y-2">
           <button
             type="button"
@@ -353,68 +369,70 @@ export default function BillingClient({
               : "Update payment method, switch plans, or cancel."}
           </p>
         </div>
-      ) : isActive && subscription?.provider === "paypal" && subscription?.hasPayPalSubscription ? (
+      ) : hasManageablePayPalSubscription ? (
         <div className="space-y-4">
-          <section className="space-y-2.5">
-            <div className="flex items-center justify-between">
-              <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-                Switch Plan
-              </h2>
-              <span className="text-[11px] text-gray-600">
-                Effective next billing cycle
-              </span>
-            </div>
-            <div className="space-y-2">
-              {SUPPORTER_TIER_PLANS.map((plan) => {
-                const isCurrent = isSameSupportPlan(subscription.tier, plan.tier);
-                const isPending = isSameSupportPlan(subscription.pendingTier, plan.tier);
-                const isLoading = paypalSwitchLoadingTier === plan.tier;
-                return (
-                  <div
-                    key={plan.tier}
-                    className={`flex items-center gap-3 rounded-md border px-4 py-2.5 ${
-                      isCurrent
-                        ? "border-indigo-500/30 bg-indigo-500/10"
-                        : isPending
-                          ? "border-gray-700 bg-gray-800/35"
-                          : "border-gray-800 bg-gray-800/20"
-                    }`}
-                  >
-                    <SupporterBadge tier={plan.tier} size="sm" showTooltip={false} />
-                    <div className="min-w-0 flex-1">
-                      <span className="text-sm font-semibold text-white">
-                        {plan.label}
-                      </span>
+          {isActive && (
+            <section className="space-y-2.5">
+              <div className="flex items-center justify-between">
+                <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                  Switch Plan
+                </h2>
+                <span className="text-[11px] text-gray-600">
+                  Effective next billing cycle
+                </span>
+              </div>
+              <div className="space-y-2">
+                {SUPPORTER_TIER_PLANS.map((plan) => {
+                  const isCurrent = isSameSupportPlan(subscription.tier, plan.tier);
+                  const isPending = isSameSupportPlan(subscription.pendingTier, plan.tier);
+                  const isLoading = paypalSwitchLoadingTier === plan.tier;
+                  return (
+                    <div
+                      key={plan.tier}
+                      className={`flex items-center gap-3 rounded-md border px-4 py-2.5 ${
+                        isCurrent
+                          ? "border-indigo-500/30 bg-indigo-500/10"
+                          : isPending
+                            ? "border-gray-700 bg-gray-800/35"
+                            : "border-gray-800 bg-gray-800/20"
+                      }`}
+                    >
+                      <SupporterBadge tier={plan.tier} size="sm" showTooltip={false} />
+                      <div className="min-w-0 flex-1">
+                        <span className="text-sm font-semibold text-white">
+                          {plan.label}
+                        </span>
+                      </div>
+                      {isCurrent ? (
+                        <span className="shrink-0 rounded-md bg-indigo-500/20 px-3 py-1 text-[11px] font-medium text-indigo-300">
+                          Current
+                        </span>
+                      ) : isPending ? (
+                        <span className="shrink-0 rounded-md bg-gray-700/70 px-3 py-1 text-[11px] font-medium text-gray-200">
+                          Scheduled
+                        </span>
+                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => schedulePayPalPlanChange(plan.tier)}
+                          disabled={paypalSwitchLoadingTier !== null || paypalCancelLoading}
+                          className="shrink-0 rounded-md border border-gray-700 px-3 py-1 text-[11px] font-medium text-gray-300 hover:bg-gray-800 hover:border-gray-600 transition-colors disabled:opacity-50"
+                        >
+                          {isLoading ? "Scheduling..." : "Switch"}
+                        </button>
+                      )}
                     </div>
-                    {isCurrent ? (
-                      <span className="shrink-0 rounded-md bg-indigo-500/20 px-3 py-1 text-[11px] font-medium text-indigo-300">
-                        Current
-                      </span>
-                    ) : isPending ? (
-                      <span className="shrink-0 rounded-md bg-gray-700/70 px-3 py-1 text-[11px] font-medium text-gray-200">
-                        Scheduled
-                      </span>
-                    ) : (
-                      <button
-                        type="button"
-                        onClick={() => schedulePayPalPlanChange(plan.tier)}
-                        disabled={paypalSwitchLoadingTier !== null || paypalCancelLoading}
-                        className="shrink-0 rounded-md border border-gray-700 px-3 py-1 text-[11px] font-medium text-gray-300 hover:bg-gray-800 hover:border-gray-600 transition-colors disabled:opacity-50"
-                      >
-                        {isLoading ? "Scheduling..." : "Switch"}
-                      </button>
-                    )}
-                  </div>
-                );
-              })}
-            </div>
-            {subscription.pendingTierLabel && subscription.currentPeriodEnd && (
-              <p className="text-xs text-gray-300">
-                Switching to {subscription.pendingTierLabel} on{" "}
-                {formatDate(subscription.currentPeriodEnd)}.
-              </p>
-            )}
-          </section>
+                  );
+                })}
+              </div>
+              {subscription.pendingTierLabel && subscription.currentPeriodEnd && (
+                <p className="text-xs text-gray-300">
+                  Switching to {subscription.pendingTierLabel} on{" "}
+                  {formatDate(subscription.currentPeriodEnd)}.
+                </p>
+              )}
+            </section>
+          )}
 
           <section className="rounded-md border border-gray-800 bg-gray-800/20 p-3 space-y-2.5">
             <h3 className="text-xs font-medium uppercase tracking-wider text-gray-500">
@@ -423,14 +441,16 @@ export default function BillingClient({
             <p className="text-[11px] text-gray-400">
               You can manage this subscription in your PayPal account at any time.
             </p>
-            <button
-              type="button"
-              onClick={cancelPayPal}
-              disabled={paypalCancelLoading || paypalSwitchLoadingTier !== null}
-              className="w-full rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-400 hover:text-red-400 hover:border-red-900/60 transition-colors disabled:opacity-50"
-            >
-              {paypalCancelLoading ? "Cancelling..." : "Cancel at period end"}
-            </button>
+            {!subscription.cancelAtPeriodEnd && (
+              <button
+                type="button"
+                onClick={cancelPayPal}
+                disabled={paypalCancelLoading || paypalSwitchLoadingTier !== null}
+                className="w-full rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-400 hover:text-red-400 hover:border-red-900/60 transition-colors disabled:opacity-50"
+              >
+                {paypalCancelLoading ? "Cancelling..." : "Cancel at period end"}
+              </button>
+            )}
             {subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd && (
               <p className="text-[11px] text-yellow-300/90">
                 Your access remains active until {formatDate(subscription.currentPeriodEnd)}.
@@ -438,7 +458,7 @@ export default function BillingClient({
             )}
           </section>
         </div>
-      ) : subscription?.hasStripeCustomer && !isActive ? (
+      ) : subscription?.provider === "stripe" && subscription?.hasStripeCustomer && !isActive ? (
         <div className="space-y-3">
           <p className="text-sm text-gray-400 text-center">
             Your subscription is no longer active. You can resubscribe anytime.

--- a/src/app/billing/_components/BillingClient.tsx
+++ b/src/app/billing/_components/BillingClient.tsx
@@ -8,32 +8,39 @@ import {
   appendTrackedCheckoutSessionId,
   hasTrackedCheckoutSessionId,
   isActiveSupportSubscriptionStatus,
+  isSameSupportPlan,
   shouldTrackSupportSubscribeSuccess,
   TRACKED_CHECKOUT_SESSION_IDS_KEY,
 } from "../_lib/supportSubscribeAnalytics";
+import { SUPPORTER_TIER_PLANS } from "@/app/contribute/_lib/supporterTierPlans";
 
 type SubscriptionInfo = {
+  provider: "stripe" | "paypal" | null;
   tier: number;
   tierLabel: string;
   status: string;
   cancelAtPeriodEnd: boolean;
   currentPeriodEnd: string | null;
   hasStripeCustomer: boolean;
+  hasPayPalSubscription: boolean;
+  pendingTier: number | null;
+  pendingTierLabel: string | null;
 };
 
 type BillingClientProps = {
   checkoutStatus: "success" | "cancel" | null;
+  switchStatus: "scheduled" | "cancel" | null;
   checkoutSessionId: string | null;
   subscription: SubscriptionInfo | null;
   isSignedIn: boolean;
 };
 
 const STATUS_DISPLAY: Record<string, { label: string; color: string }> = {
-  active: { label: "Active", color: "text-gray-200" },
-  trialing: { label: "Trial", color: "text-gray-200" },
-  past_due: { label: "Past Due", color: "text-yellow-400" },
-  canceled: { label: "Canceled", color: "text-gray-500" },
-  incomplete: { label: "Incomplete", color: "text-yellow-400" },
+  active: { label: "Active", color: "text-green-400" },
+  trialing: { label: "Trial", color: "text-green-400" },
+  past_due: { label: "Past Due", color: "text-gray-300" },
+  canceled: { label: "Canceled", color: "text-yellow-400" },
+  incomplete: { label: "Incomplete", color: "text-gray-300" },
   incomplete_expired: { label: "Expired", color: "text-red-400" },
   unpaid: { label: "Unpaid", color: "text-red-400" },
   none: { label: "—", color: "text-gray-600" },
@@ -46,6 +53,13 @@ function formatDate(iso: string | null): string {
     day: "numeric",
     year: "numeric",
   });
+}
+
+function isFutureDate(iso: string | null): boolean {
+  if (!iso) return false;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return false;
+  return parsed.getTime() > Date.now();
 }
 
 function readTrackedCheckoutSessionIds(): string[] {
@@ -72,15 +86,31 @@ function writeTrackedCheckoutSessionIds(sessionIds: string[]) {
 
 export default function BillingClient({
   checkoutStatus,
+  switchStatus,
   checkoutSessionId,
   subscription,
   isSignedIn,
 }: BillingClientProps) {
   const [portalLoading, setPortalLoading] = useState(false);
+  const [paypalCancelLoading, setPaypalCancelLoading] = useState(false);
+  const [paypalSwitchLoadingTier, setPaypalSwitchLoadingTier] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
   const hasTrackedSubscribeSuccess = useRef(false);
 
   const isActive = isActiveSupportSubscriptionStatus(subscription?.status);
+  const hasGraceAccess =
+    Boolean(subscription?.cancelAtPeriodEnd) && isFutureDate(subscription?.currentPeriodEnd ?? null);
+  const showsAccessUntilState = isActive || hasGraceAccess;
+  const shouldShowSyncHint = checkoutStatus === "success" || switchStatus === "scheduled";
+  const syncRefreshKey = useMemo(() => {
+    if (checkoutStatus === "success") {
+      return `billing-sync-checkout-${checkoutSessionId ?? "unknown"}`;
+    }
+    if (switchStatus === "scheduled") {
+      return "billing-sync-switch-scheduled";
+    }
+    return null;
+  }, [checkoutStatus, checkoutSessionId, switchStatus]);
 
   const statusInfo = STATUS_DISPLAY[subscription?.status ?? "none"] ?? STATUS_DISPLAY.none;
 
@@ -91,8 +121,16 @@ export default function BillingClient({
     if (checkoutStatus === "cancel") {
       return "Checkout was canceled. You can subscribe anytime from the Contribute page.";
     }
+    if (switchStatus === "scheduled") {
+      return "Your plan change is scheduled for the next billing cycle.";
+    }
+    if (switchStatus === "cancel") {
+      return "Plan change approval was canceled. Your current tier stays the same.";
+    }
     return null;
-  }, [checkoutStatus]);
+  }, [checkoutStatus, switchStatus]);
+  const isSuccessStatusMessage =
+    checkoutStatus === "success" || switchStatus === "scheduled";
 
   useEffect(() => {
     if (hasTrackedSubscribeSuccess.current) return;
@@ -120,6 +158,21 @@ export default function BillingClient({
     });
   }, [checkoutStatus, checkoutSessionId, subscription?.status, subscription?.tier]);
 
+  useEffect(() => {
+    if (!syncRefreshKey) return;
+    if (typeof window === "undefined") return;
+    try {
+      if (window.sessionStorage.getItem(syncRefreshKey) === "1") return;
+      window.sessionStorage.setItem(syncRefreshKey, "1");
+    } catch {
+      return;
+    }
+    const timeout = window.setTimeout(() => {
+      window.location.reload();
+    }, 8000);
+    return () => window.clearTimeout(timeout);
+  }, [syncRefreshKey]);
+
   const openBillingPortal = async () => {
     setError(null);
     setPortalLoading(true);
@@ -135,6 +188,44 @@ export default function BillingClient({
     } catch (err) {
       setError(err instanceof Error ? err.message : "Unable to open billing portal.");
       setPortalLoading(false);
+    }
+  };
+
+  const cancelPayPal = async () => {
+    setError(null);
+    setPaypalCancelLoading(true);
+    try {
+      const response = await fetch("/api/billing/cancel-paypal-subscription", {
+        method: "POST",
+      });
+      const payload = await response.json();
+      if (!response.ok) {
+        throw new Error(payload?.error ?? "Unable to cancel PayPal subscription.");
+      }
+      window.location.reload();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to cancel PayPal subscription.");
+      setPaypalCancelLoading(false);
+    }
+  };
+
+  const schedulePayPalPlanChange = async (tier: number) => {
+    setError(null);
+    setPaypalSwitchLoadingTier(tier);
+    try {
+      const response = await fetch("/api/billing/change-paypal-plan", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ tier }),
+      });
+      const payload = await response.json();
+      if (!response.ok || !payload?.url) {
+        throw new Error(payload?.error ?? "Unable to schedule PayPal plan change.");
+      }
+      window.location.assign(payload.url);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unable to schedule PayPal plan change.");
+      setPaypalSwitchLoadingTier(null);
     }
   };
 
@@ -167,12 +258,17 @@ export default function BillingClient({
       {statusMessage && (
         <div
           className={`rounded-md border px-4 py-2.5 text-sm ${
-            checkoutStatus === "success"
+            isSuccessStatusMessage
               ? "border-indigo-500/40 bg-indigo-500/15 text-indigo-200"
-              : "border-yellow-900/60 bg-yellow-900/20 text-yellow-300"
+              : "border-gray-700 bg-gray-800/40 text-gray-300"
           }`}
         >
           {statusMessage}
+          {shouldShowSyncHint && (
+            <p className="mt-1 text-xs text-gray-300">
+              Billing updates can take up to a minute to appear.
+            </p>
+          )}
         </div>
       )}
 
@@ -199,12 +295,25 @@ export default function BillingClient({
 
         <div className="px-5 py-4 flex items-center justify-between">
           <div className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Provider
+          </div>
+          <span className="text-sm font-medium text-gray-300">
+            {subscription?.provider === "paypal"
+              ? "PayPal"
+              : subscription?.provider === "stripe"
+                ? "Stripe"
+                : "—"}
+          </span>
+        </div>
+
+        <div className="px-5 py-4 flex items-center justify-between">
+          <div className="text-xs font-medium text-gray-500 uppercase tracking-wider">
             Status
           </div>
-          {subscription?.cancelAtPeriodEnd && isActive ? (
+          {subscription?.cancelAtPeriodEnd && showsAccessUntilState ? (
             <span className="inline-flex items-center gap-1.5 text-sm">
               <span className="h-1.5 w-1.5 rounded-full bg-amber-500/70 shrink-0" />
-              <span className="text-gray-400 font-medium">Cancels at period end</span>
+              <span className="text-yellow-300 font-medium">Cancels at period end</span>
             </span>
           ) : (
             <span className="inline-flex items-center gap-1.5 text-sm">
@@ -216,7 +325,7 @@ export default function BillingClient({
           )}
         </div>
 
-        {isActive && subscription?.currentPeriodEnd && (
+        {showsAccessUntilState && subscription?.currentPeriodEnd && (
           <div className="px-5 py-4 flex items-center justify-between">
             <div className="text-xs font-medium text-gray-500 uppercase tracking-wider">
               {subscription.cancelAtPeriodEnd ? "Access Until" : "Next Billing"}
@@ -243,6 +352,91 @@ export default function BillingClient({
               ? "No further charges — you can resubscribe any time."
               : "Update payment method, switch plans, or cancel."}
           </p>
+        </div>
+      ) : isActive && subscription?.provider === "paypal" && subscription?.hasPayPalSubscription ? (
+        <div className="space-y-4">
+          <section className="space-y-2.5">
+            <div className="flex items-center justify-between">
+              <h2 className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+                Switch Plan
+              </h2>
+              <span className="text-[11px] text-gray-600">
+                Effective next billing cycle
+              </span>
+            </div>
+            <div className="space-y-2">
+              {SUPPORTER_TIER_PLANS.map((plan) => {
+                const isCurrent = isSameSupportPlan(subscription.tier, plan.tier);
+                const isPending = isSameSupportPlan(subscription.pendingTier, plan.tier);
+                const isLoading = paypalSwitchLoadingTier === plan.tier;
+                return (
+                  <div
+                    key={plan.tier}
+                    className={`flex items-center gap-3 rounded-md border px-4 py-2.5 ${
+                      isCurrent
+                        ? "border-indigo-500/30 bg-indigo-500/10"
+                        : isPending
+                          ? "border-gray-700 bg-gray-800/35"
+                          : "border-gray-800 bg-gray-800/20"
+                    }`}
+                  >
+                    <SupporterBadge tier={plan.tier} size="sm" showTooltip={false} />
+                    <div className="min-w-0 flex-1">
+                      <span className="text-sm font-semibold text-white">
+                        {plan.label}
+                      </span>
+                    </div>
+                    {isCurrent ? (
+                      <span className="shrink-0 rounded-md bg-indigo-500/20 px-3 py-1 text-[11px] font-medium text-indigo-300">
+                        Current
+                      </span>
+                    ) : isPending ? (
+                      <span className="shrink-0 rounded-md bg-gray-700/70 px-3 py-1 text-[11px] font-medium text-gray-200">
+                        Scheduled
+                      </span>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => schedulePayPalPlanChange(plan.tier)}
+                        disabled={paypalSwitchLoadingTier !== null || paypalCancelLoading}
+                        className="shrink-0 rounded-md border border-gray-700 px-3 py-1 text-[11px] font-medium text-gray-300 hover:bg-gray-800 hover:border-gray-600 transition-colors disabled:opacity-50"
+                      >
+                        {isLoading ? "Scheduling..." : "Switch"}
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+            {subscription.pendingTierLabel && subscription.currentPeriodEnd && (
+              <p className="text-xs text-gray-300">
+                Switching to {subscription.pendingTierLabel} on{" "}
+                {formatDate(subscription.currentPeriodEnd)}.
+              </p>
+            )}
+          </section>
+
+          <section className="rounded-md border border-gray-800 bg-gray-800/20 p-3 space-y-2.5">
+            <h3 className="text-xs font-medium uppercase tracking-wider text-gray-500">
+              Subscription Management
+            </h3>
+            <p className="text-[11px] text-gray-400">
+              You can manage this subscription in your PayPal account at any time.
+            </p>
+            <button
+              type="button"
+              onClick={cancelPayPal}
+              disabled={paypalCancelLoading || paypalSwitchLoadingTier !== null}
+              className="w-full rounded-md border border-gray-700 px-3 py-2 text-xs font-medium text-gray-400 hover:text-red-400 hover:border-red-900/60 transition-colors disabled:opacity-50"
+            >
+              {paypalCancelLoading ? "Cancelling..." : "Cancel at period end"}
+            </button>
+            {subscription.cancelAtPeriodEnd && subscription.currentPeriodEnd && (
+              <p className="text-[11px] text-yellow-300/90">
+                Your access remains active until {formatDate(subscription.currentPeriodEnd)}.
+              </p>
+            )}
+          </section>
         </div>
       ) : subscription?.hasStripeCustomer && !isActive ? (
         <div className="space-y-3">
@@ -280,9 +474,6 @@ export default function BillingClient({
         </div>
       )}
 
-      <p className="text-xs text-gray-600 text-center">
-        Payment processing by Stripe. Card details are never stored by divoxutils.
-      </p>
     </div>
   );
 }

--- a/src/app/billing/_lib/supportSubscribeAnalytics.ts
+++ b/src/app/billing/_lib/supportSubscribeAnalytics.ts
@@ -28,3 +28,8 @@ export function appendTrackedCheckoutSessionId(
   if (trackedSessionIds.includes(checkoutSessionId)) return trackedSessionIds;
   return [...trackedSessionIds, checkoutSessionId].slice(-50);
 }
+
+export function isSameSupportPlan(a: number | null | undefined, b: number | null | undefined) {
+  if (typeof a !== "number" || typeof b !== "number") return false;
+  return a === b;
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -24,6 +24,7 @@ type BillingPageProps = {
   searchParams?: {
     checkout?: "success" | "cancel";
     switch?: "scheduled" | "cancel";
+    provider?: "paypal";
     session_id?: string;
   };
 };
@@ -62,6 +63,7 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
     searchParams?.switch === "scheduled" || searchParams?.switch === "cancel"
       ? searchParams.switch
       : null;
+  const switchProvider = searchParams?.provider === "paypal" ? "paypal" : null;
 
   const paypalEnabled = isPayPalSubscriptionsEnabled();
 
@@ -113,6 +115,20 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
             : user.stripeSubscriptionId || user.stripeCustomerId
               ? "stripe"
               : null);
+        if (
+          switchStatus === "cancel" &&
+          switchProvider === "paypal" &&
+          provider === "paypal" &&
+          resolvedPendingPriceId
+        ) {
+          resolvedPendingPriceId = null;
+          await prisma.user.update({
+            where: { clerkUserId: userId },
+            data: {
+              pendingSubscriptionPriceId: null,
+            },
+          });
+        }
         if (provider && user.subscriptionProvider !== provider) {
           await prisma.user.update({
             where: { clerkUserId: userId },
@@ -203,6 +219,8 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
             await prisma.user.update({
               where: { clerkUserId: userId },
               data: {
+                stripeCustomerId: null,
+                stripeSubscriptionId: null,
                 paypalSubscriptionId: remoteSubscription.id,
                 paypalPayerId: remoteSubscription.payerId,
                 subscriptionStatus: resolvedStatus,
@@ -235,8 +253,8 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
           currentPeriodEnd: resolvedPeriodEnd
             ? resolvedPeriodEnd.toISOString()
             : null,
-          hasStripeCustomer: !!user.stripeCustomerId,
-          hasPayPalSubscription: !!user.paypalSubscriptionId,
+          hasStripeCustomer: provider === "stripe" && !!user.stripeCustomerId,
+          hasPayPalSubscription: provider === "paypal" && !!user.paypalSubscriptionId,
           pendingTier: pendingTier > 0 ? pendingTier : null,
           pendingTierLabel: pendingTier > 0 ? TIER_LABELS[pendingTier] ?? null : null,
         };

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -50,6 +50,16 @@ const resolveRemotePeriodSeconds = (
   return null;
 };
 
+const hasFutureGraceAccess = (params: {
+  cancelAtPeriodEnd: boolean;
+  periodEnd: Date | null;
+  nowMs?: number;
+}): boolean => {
+  if (!params.cancelAtPeriodEnd || !params.periodEnd) return false;
+  const nowMs = params.nowMs ?? Date.now();
+  return params.periodEnd.getTime() > nowMs;
+};
+
 const BillingPage = async ({ searchParams }: BillingPageProps) => {
   const checkoutStatus =
     searchParams?.checkout === "success" || searchParams?.checkout === "cancel"
@@ -212,8 +222,13 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
             resolvedPeriodEnd = remoteSubscription.nextBillingTime
               ? new Date(remoteSubscription.nextBillingTime)
               : resolvedPeriodEnd;
+            const hasPayPalGraceAccess = hasFutureGraceAccess({
+              cancelAtPeriodEnd: resolvedCancelAtPeriodEnd,
+              periodEnd: resolvedPeriodEnd,
+            });
             const resolvedTierFromPayPal =
-              paypalEnabled && isActiveSubscriptionStatus(resolvedStatus)
+              paypalEnabled &&
+              (isActiveSubscriptionStatus(resolvedStatus) || hasPayPalGraceAccess)
                 ? getTierFromPriceId(resolvedPriceId, getPayPalPlanMap())
                 : 0;
             await prisma.user.update({
@@ -236,9 +251,14 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
         }
 
         const isActive = isActiveSubscriptionStatus(resolvedStatus);
+        const hasGraceAccess = hasFutureGraceAccess({
+          cancelAtPeriodEnd: resolvedCancelAtPeriodEnd,
+          periodEnd: resolvedPeriodEnd,
+        });
         const providerPriceMap =
           provider === "paypal" && paypalEnabled ? getPayPalPlanMap() : getStripePriceMap();
-        const tier = isActive ? getTierFromPriceId(resolvedPriceId, providerPriceMap) : 0;
+        const tier =
+          isActive || hasGraceAccess ? getTierFromPriceId(resolvedPriceId, providerPriceMap) : 0;
         const pendingTier =
           provider === "paypal" && paypalEnabled && resolvedPendingPriceId
             ? getTierFromPriceId(resolvedPendingPriceId, getPayPalPlanMap())

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -3,11 +3,17 @@ import { auth } from "@clerk/nextjs/server";
 import type Stripe from "stripe";
 import prisma from "../../../prisma/prismaClient";
 import {
+  isPayPalSubscriptionsEnabled,
+  fetchPayPalSubscription,
+  getPayPalPlanMap,
+} from "@/server/billing/paypal";
+import {
   getStripeClient,
   getStripePriceMap,
   getTierFromPriceId,
   shouldGrantSupporterBadge,
 } from "@/server/billing/stripe";
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
 import BillingClient from "./_components/BillingClient";
 
 export const metadata = {
@@ -17,6 +23,7 @@ export const metadata = {
 type BillingPageProps = {
   searchParams?: {
     checkout?: "success" | "cancel";
+    switch?: "scheduled" | "cancel";
     session_id?: string;
   };
 };
@@ -51,14 +58,24 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
     typeof searchParams?.session_id === "string" && searchParams.session_id.length > 0
       ? searchParams.session_id
       : null;
+  const switchStatus =
+    searchParams?.switch === "scheduled" || searchParams?.switch === "cancel"
+      ? searchParams.switch
+      : null;
+
+  const paypalEnabled = isPayPalSubscriptionsEnabled();
 
   let subscription: {
+    provider: "stripe" | "paypal" | null;
     tier: number;
     tierLabel: string;
     status: string;
     cancelAtPeriodEnd: boolean;
     currentPeriodEnd: string | null;
     hasStripeCustomer: boolean;
+    hasPayPalSubscription: boolean;
+    pendingTier: number | null;
+    pendingTierLabel: string | null;
   } | null = null;
   let isSignedIn = false;
 
@@ -74,77 +91,143 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
           subscriptionCancelAtPeriodEnd: true,
           subscriptionCurrentPeriodEnd: true,
           subscriptionPriceId: true,
+          pendingSubscriptionPriceId: true,
           stripeSubscriptionId: true,
           stripeCustomerId: true,
+          subscriptionProvider: true,
+          paypalSubscriptionId: true,
+          paypalPayerId: true,
         },
       });
 
       if (user) {
         let resolvedStatus = user.subscriptionStatus ?? "none";
         let resolvedPriceId = user.subscriptionPriceId ?? null;
+        let resolvedPendingPriceId = user.pendingSubscriptionPriceId ?? null;
         let resolvedCancelAtPeriodEnd = user.subscriptionCancelAtPeriodEnd;
         let resolvedPeriodEnd = user.subscriptionCurrentPeriodEnd;
-        let remoteSubscription: Stripe.Subscription | null = null;
-        if (user.stripeSubscriptionId) {
-          try {
-            remoteSubscription = await getStripeClient().subscriptions.retrieve(
-              user.stripeSubscriptionId,
-              { expand: ["items.data.price"] }
-            );
-          } catch {
-          }
-        }
-        if (!remoteSubscription && user.stripeCustomerId) {
-          try {
-            const subscriptions = await getStripeClient().subscriptions.list({
-              customer: user.stripeCustomerId,
-              status: "all",
-              limit: 10,
-              expand: ["data.items.data.price"],
-            });
-            remoteSubscription =
-              subscriptions.data.find((sub) => sub.id === user.stripeSubscriptionId) ??
-              subscriptions.data[0] ??
-              null;
-          } catch {
-          }
-        }
-        if (remoteSubscription) {
-          resolvedStatus = remoteSubscription.status;
-          resolvedPriceId = remoteSubscription.items.data[0]?.price?.id ?? resolvedPriceId;
-          resolvedCancelAtPeriodEnd = Boolean(
-            remoteSubscription.cancel_at_period_end || remoteSubscription.cancel_at
-          );
-          const remotePeriodSeconds = resolveRemotePeriodSeconds(remoteSubscription);
-          resolvedPeriodEnd =
-            typeof remotePeriodSeconds === "number" && Number.isFinite(remotePeriodSeconds)
-              ? new Date(remotePeriodSeconds * 1000)
-              : resolvedPeriodEnd;
-          const resolvedTierFromStripe = shouldGrantSupporterBadge(resolvedStatus)
-            ? getTierFromPriceId(resolvedPriceId, getStripePriceMap())
-            : 0;
+        const provider =
+          user.subscriptionProvider ??
+          (user.paypalSubscriptionId
+            ? "paypal"
+            : user.stripeSubscriptionId || user.stripeCustomerId
+              ? "stripe"
+              : null);
+        if (provider && user.subscriptionProvider !== provider) {
           await prisma.user.update({
             where: { clerkUserId: userId },
             data: {
-              stripeSubscriptionId: remoteSubscription.id,
-              subscriptionStatus: resolvedStatus,
-              subscriptionPriceId: resolvedPriceId,
-              subscriptionCancelAtPeriodEnd: resolvedCancelAtPeriodEnd,
-              subscriptionCurrentPeriodEnd: resolvedPeriodEnd,
-              supporterTier: resolvedTierFromStripe,
+              subscriptionProvider: provider,
+              subscriptionProviderUpdatedAt: new Date(),
             },
           });
         }
+        if (provider === "stripe") {
+          let remoteSubscription: Stripe.Subscription | null = null;
+          if (user.stripeSubscriptionId) {
+            try {
+              remoteSubscription = await getStripeClient().subscriptions.retrieve(
+                user.stripeSubscriptionId,
+                { expand: ["items.data.price"] }
+              );
+            } catch {
+            }
+          }
+          if (!remoteSubscription && user.stripeCustomerId) {
+            try {
+              const subscriptions = await getStripeClient().subscriptions.list({
+                customer: user.stripeCustomerId,
+                status: "all",
+                limit: 10,
+                expand: ["data.items.data.price"],
+              });
+              remoteSubscription =
+                subscriptions.data.find((sub) => sub.id === user.stripeSubscriptionId) ??
+                subscriptions.data[0] ??
+                null;
+            } catch {
+            }
+          }
+          if (remoteSubscription) {
+            resolvedStatus = remoteSubscription.status;
+            resolvedPriceId = remoteSubscription.items.data[0]?.price?.id ?? resolvedPriceId;
+            resolvedCancelAtPeriodEnd = Boolean(
+              remoteSubscription.cancel_at_period_end || remoteSubscription.cancel_at
+            );
+            const remotePeriodSeconds = resolveRemotePeriodSeconds(remoteSubscription);
+            resolvedPeriodEnd =
+              typeof remotePeriodSeconds === "number" && Number.isFinite(remotePeriodSeconds)
+                ? new Date(remotePeriodSeconds * 1000)
+                : resolvedPeriodEnd;
+            const resolvedTierFromStripe = shouldGrantSupporterBadge(resolvedStatus)
+              ? getTierFromPriceId(resolvedPriceId, getStripePriceMap())
+              : 0;
+            await prisma.user.update({
+              where: { clerkUserId: userId },
+              data: {
+                stripeSubscriptionId: remoteSubscription.id,
+                subscriptionStatus: resolvedStatus,
+                subscriptionPriceId: resolvedPriceId,
+                subscriptionCancelAtPeriodEnd: resolvedCancelAtPeriodEnd,
+                subscriptionCurrentPeriodEnd: resolvedPeriodEnd,
+                supporterTier: resolvedTierFromStripe,
+                pendingSubscriptionPriceId: null,
+              },
+            });
+          }
+        }
+        if (provider === "paypal" && paypalEnabled && user.paypalSubscriptionId) {
+          try {
+            const remoteSubscription = await fetchPayPalSubscription(user.paypalSubscriptionId);
+            resolvedStatus = remoteSubscription.status ?? resolvedStatus;
+            const now = Date.now();
+            const previousPeriodEndMs = resolvedPeriodEnd ? resolvedPeriodEnd.getTime() : null;
+            const shouldPromotePendingPrice =
+              Boolean(resolvedPendingPriceId) &&
+              remoteSubscription.planId === resolvedPendingPriceId &&
+              (previousPeriodEndMs === null || previousPeriodEndMs <= now);
+            if (shouldPromotePendingPrice) {
+              resolvedPriceId = resolvedPendingPriceId;
+              resolvedPendingPriceId = null;
+            } else if (!resolvedPendingPriceId) {
+              resolvedPriceId = remoteSubscription.planId ?? resolvedPriceId;
+            }
+            resolvedCancelAtPeriodEnd = remoteSubscription.cancelAtPeriodEnd;
+            resolvedPeriodEnd = remoteSubscription.nextBillingTime
+              ? new Date(remoteSubscription.nextBillingTime)
+              : resolvedPeriodEnd;
+            const resolvedTierFromPayPal =
+              paypalEnabled && isActiveSubscriptionStatus(resolvedStatus)
+                ? getTierFromPriceId(resolvedPriceId, getPayPalPlanMap())
+                : 0;
+            await prisma.user.update({
+              where: { clerkUserId: userId },
+              data: {
+                paypalSubscriptionId: remoteSubscription.id,
+                paypalPayerId: remoteSubscription.payerId,
+                subscriptionStatus: resolvedStatus,
+                subscriptionPriceId: resolvedPriceId,
+                pendingSubscriptionPriceId: resolvedPendingPriceId,
+                subscriptionCancelAtPeriodEnd: resolvedCancelAtPeriodEnd,
+                subscriptionCurrentPeriodEnd: resolvedPeriodEnd,
+                supporterTier: resolvedTierFromPayPal,
+              },
+            });
+          } catch {
+          }
+        }
 
-        const isActive =
-          resolvedStatus === "active" ||
-          resolvedStatus === "trialing" ||
-          resolvedStatus === "past_due";
-        const tier = isActive
-          ? getTierFromPriceId(resolvedPriceId, getStripePriceMap())
-          : 0;
+        const isActive = isActiveSubscriptionStatus(resolvedStatus);
+        const providerPriceMap =
+          provider === "paypal" && paypalEnabled ? getPayPalPlanMap() : getStripePriceMap();
+        const tier = isActive ? getTierFromPriceId(resolvedPriceId, providerPriceMap) : 0;
+        const pendingTier =
+          provider === "paypal" && paypalEnabled && resolvedPendingPriceId
+            ? getTierFromPriceId(resolvedPendingPriceId, getPayPalPlanMap())
+            : 0;
 
         subscription = {
+          provider,
           tier,
           tierLabel: TIER_LABELS[tier] ?? "None",
           status: resolvedStatus,
@@ -153,6 +236,9 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
             ? resolvedPeriodEnd.toISOString()
             : null,
           hasStripeCustomer: !!user.stripeCustomerId,
+          hasPayPalSubscription: !!user.paypalSubscriptionId,
+          pendingTier: pendingTier > 0 ? pendingTier : null,
+          pendingTierLabel: pendingTier > 0 ? TIER_LABELS[pendingTier] ?? null : null,
         };
       }
     }
@@ -164,6 +250,7 @@ const BillingPage = async ({ searchParams }: BillingPageProps) => {
     <div className="min-h-screen bg-gray-900 text-gray-300">
       <BillingClient
         checkoutStatus={checkoutStatus}
+        switchStatus={switchStatus}
         checkoutSessionId={checkoutSessionId}
         subscription={subscription}
         isSignedIn={isSignedIn}

--- a/src/app/contribute/_components/SubscribeInline.tsx
+++ b/src/app/contribute/_components/SubscribeInline.tsx
@@ -4,24 +4,34 @@ import { useState } from "react";
 import { useAuth } from "@clerk/nextjs";
 import Link from "next/link";
 import SupporterBadge from "@/components/support/SupporterBadge";
+import PaymentProviderToggle, {
+  type PaymentProvider,
+} from "@/components/support/PaymentProviderToggle";
 import { SUPPORTER_TIER_PLANS } from "../_lib/supporterTierPlans";
 
 type Props = {
   activeTier: number | null;
+  paypalEnabled: boolean;
 };
 
-export default function SubscribeInline({ activeTier }: Props) {
+export default function SubscribeInline({ activeTier, paypalEnabled }: Props) {
   const { isSignedIn } = useAuth();
+  const [provider, setProvider] = useState<PaymentProvider>("stripe");
   const [loadingTier, setLoadingTier] = useState<number | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const isSubscribed = activeTier !== null;
+  const activeProvider = paypalEnabled ? provider : "stripe";
 
   const startCheckout = async (tier: number) => {
     setError(null);
     setLoadingTier(tier);
     try {
-      const response = await fetch("/api/billing/create-checkout-session", {
+      const endpoint =
+        activeProvider === "paypal"
+          ? "/api/billing/create-paypal-subscription"
+          : "/api/billing/create-checkout-session";
+      const response = await fetch(endpoint, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ tier }),
@@ -32,7 +42,11 @@ export default function SubscribeInline({ activeTier }: Props) {
       }
       window.location.assign(payload.url);
     } catch (err) {
-      setError(err instanceof Error ? err.message : "Unable to start checkout.");
+      const fallbackError =
+        activeProvider === "paypal"
+          ? "Unable to start PayPal checkout."
+          : "Unable to start checkout.";
+      setError(err instanceof Error ? err.message : fallbackError);
       setLoadingTier(null);
     }
   };
@@ -46,6 +60,19 @@ export default function SubscribeInline({ activeTier }: Props) {
       {error && (
         <div className="rounded-md border border-red-900/60 bg-red-900/20 px-4 py-2 text-sm text-red-300">
           {error}
+        </div>
+      )}
+
+      {!isSubscribed && isSignedIn && paypalEnabled && (
+        <div className="space-y-1.5">
+          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
+            Payment method
+          </p>
+          <PaymentProviderToggle
+            value={provider}
+            onChange={setProvider}
+            disabled={loadingTier !== null}
+          />
         </div>
       )}
 
@@ -102,22 +129,10 @@ export default function SubscribeInline({ activeTier }: Props) {
       </div>
 
       <p className="text-xs text-gray-500 text-center pt-1">
-        {isSubscribed ? (
-          <>
-            To switch tiers, go to{" "}
-            <Link href="/billing" className="text-indigo-400 hover:text-indigo-300">
-              Manage Subscription
-            </Link>{" "}
-            and select a new plan.
-          </>
-        ) : (
-          <>
-            Secure checkout powered by Stripe. Already subscribed?{" "}
-            <Link href="/billing" className="text-indigo-400 hover:text-indigo-300">
-              Manage your subscription
-            </Link>
-          </>
-        )}
+        Secure checkout powered by Stripe{paypalEnabled ? " and PayPal" : ""}. Already subscribed?{" "}
+        <Link href="/billing" className="text-indigo-400 hover:text-indigo-300">
+          Manage your subscription
+        </Link>
       </p>
     </section>
   );

--- a/src/app/contribute/_components/SubscribeInline.tsx
+++ b/src/app/contribute/_components/SubscribeInline.tsx
@@ -64,10 +64,7 @@ export default function SubscribeInline({ activeTier, paypalEnabled }: Props) {
       )}
 
       {!isSubscribed && isSignedIn && paypalEnabled && (
-        <div className="space-y-1.5">
-          <p className="text-xs font-medium text-gray-500 uppercase tracking-wider">
-            Payment method
-          </p>
+        <div>
           <PaymentProviderToggle
             value={provider}
             onChange={setProvider}

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -3,6 +3,9 @@ import { auth } from "@clerk/nextjs/server";
 import type { Metadata } from "next";
 import prisma from "../../../prisma/prismaClient";
 import SubscribeInline from "./_components/SubscribeInline";
+import { getPayPalPlanMap, isPayPalSubscriptionsEnabled } from "@/server/billing/paypal";
+import { getTierFromPriceId, getStripePriceMap } from "@/server/billing/stripe";
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
 
 export const metadata: Metadata = {
   title: "Contribute - divoxutils",
@@ -60,10 +63,32 @@ const ContributePage = async () => {
     if (userId) {
       const user = await prisma.user.findUnique({
         where: { clerkUserId: userId },
-        select: { supporterTier: true },
+        select: {
+          subscriptionProvider: true,
+          subscriptionStatus: true,
+          subscriptionPriceId: true,
+          stripeSubscriptionId: true,
+          stripeCustomerId: true,
+          paypalSubscriptionId: true,
+        },
       });
-      if (user?.supporterTier && user.supporterTier > 0) {
-        activeTier = user.supporterTier;
+      const provider =
+        user?.subscriptionProvider ??
+        (user?.paypalSubscriptionId
+          ? "paypal"
+          : user?.stripeSubscriptionId || user?.stripeCustomerId
+            ? "stripe"
+            : null);
+      if (
+        provider &&
+        isActiveSubscriptionStatus(user?.subscriptionStatus)
+      ) {
+        const priceMap =
+          provider === "paypal" && isPayPalSubscriptionsEnabled()
+            ? getPayPalPlanMap()
+            : getStripePriceMap();
+        const resolvedTier = getTierFromPriceId(user?.subscriptionPriceId, priceMap);
+        activeTier = resolvedTier > 0 ? resolvedTier : null;
       }
     }
   } catch {
@@ -129,7 +154,10 @@ const ContributePage = async () => {
           </div>
         </section>
 
-        <SubscribeInline activeTier={activeTier} />
+        <SubscribeInline
+          activeTier={activeTier}
+          paypalEnabled={isPayPalSubscriptionsEnabled()}
+        />
       </div>
     </div>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,7 @@ import { Toaster } from "sonner";
 import SupportPromptModal from "@/components/support/SupportPromptModal";
 import SignedOutNudge from "@/components/auth/SignedOutNudge";
 import { getLayoutViewerContext } from "@/server/layoutViewerContext";
+import { isPayPalSubscriptionsEnabled } from "@/server/billing/paypal";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -44,6 +45,7 @@ export default async function RootLayout({
   children: React.ReactNode;
 }) {
   const { isSupporter, isAdmin } = await getLayoutViewerContext();
+  const paypalEnabled = isPayPalSubscriptionsEnabled();
 
   return (
     <html lang="en">
@@ -69,7 +71,11 @@ export default async function RootLayout({
                 Skip to main content
               </a>
               <Navbar />
-              <SupportPromptModal isSupporter={isSupporter} isAdmin={isAdmin} />
+              <SupportPromptModal
+                isSupporter={isSupporter}
+                isAdmin={isAdmin}
+                paypalEnabled={paypalEnabled}
+              />
               <SignedOutNudge />
               <main id="main-content" className="flex-1 focus:outline-none" tabIndex={-1}>
                 {children}

--- a/src/app/test/support-modal/page.tsx
+++ b/src/app/test/support-modal/page.tsx
@@ -1,10 +1,12 @@
 import { notFound } from "next/navigation";
 import SupportPromptModal from "@/components/support/SupportPromptModal";
+import { isPayPalSubscriptionsEnabled } from "@/server/billing/paypal";
 
 export default function SupportModalTestPage() {
   if (process.env.NODE_ENV !== "development") {
     notFound();
   }
+  const paypalEnabled = isPayPalSubscriptionsEnabled();
 
   return (
     <div className="min-h-screen bg-gray-900 text-gray-300">
@@ -15,7 +17,7 @@ export default function SupportModalTestPage() {
             Development-only preview for cadence and modal behavior.
           </p>
         </header>
-        <SupportPromptModal debug ignorePathRules />
+        <SupportPromptModal debug ignorePathRules paypalEnabled={paypalEnabled} />
       </div>
     </div>
   );

--- a/src/components/support/PaymentProviderToggle.tsx
+++ b/src/components/support/PaymentProviderToggle.tsx
@@ -1,0 +1,189 @@
+"use client";
+
+import { ShieldCheck } from "lucide-react";
+
+export type PaymentProvider = "stripe" | "paypal";
+
+type PaymentProviderToggleProps = {
+  value: PaymentProvider;
+  onChange: (provider: PaymentProvider) => void;
+  disabled?: boolean;
+  size?: "sm" | "md";
+};
+
+function VisaMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 40 24"
+      className={className}
+      role="img"
+      aria-label="Visa"
+    >
+      <rect width="40" height="24" rx="3" fill="#1434CB" />
+      <text
+        x="20"
+        y="16.5"
+        textAnchor="middle"
+        fontFamily="Arial, Helvetica, sans-serif"
+        fontWeight="900"
+        fontStyle="italic"
+        fontSize="9.5"
+        letterSpacing="0.5"
+        fill="#ffffff"
+      >
+        VISA
+      </text>
+    </svg>
+  );
+}
+
+function MastercardMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 40 24"
+      className={className}
+      role="img"
+      aria-label="Mastercard"
+    >
+      <rect width="40" height="24" rx="3" fill="#0B0B0B" />
+      <circle cx="16" cy="12" r="6.5" fill="#EB001B" />
+      <circle cx="24" cy="12" r="6.5" fill="#F79E1B" />
+      <path
+        d="M20 7.1a6.5 6.5 0 0 1 0 9.8 6.5 6.5 0 0 1 0-9.8z"
+        fill="#FF5F00"
+      />
+    </svg>
+  );
+}
+
+function AmexMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 40 24"
+      className={className}
+      role="img"
+      aria-label="American Express"
+    >
+      <rect width="40" height="24" rx="3" fill="#1F72CD" />
+      <text
+        x="20"
+        y="16"
+        textAnchor="middle"
+        fontFamily="Arial, Helvetica, sans-serif"
+        fontWeight="900"
+        fontSize="7.5"
+        letterSpacing="0.6"
+        fill="#ffffff"
+      >
+        AMEX
+      </text>
+    </svg>
+  );
+}
+
+function PayPalMark({ className }: { className?: string }) {
+  return (
+    <svg
+      viewBox="0 0 72 24"
+      className={className}
+      role="img"
+      aria-label="PayPal"
+    >
+      <rect width="72" height="24" rx="3" fill="#ffffff" />
+      <text
+        x="6"
+        y="17"
+        fontFamily="Arial, Helvetica, sans-serif"
+        fontWeight="900"
+        fontStyle="italic"
+        fontSize="12.5"
+      >
+        <tspan fill="#003087">Pay</tspan>
+        <tspan fill="#0070BA">Pal</tspan>
+      </text>
+    </svg>
+  );
+}
+
+const OPTIONS: {
+  value: PaymentProvider;
+  label: string;
+  sublabel: string;
+}[] = [
+  { value: "stripe", label: "Card", sublabel: "Secure card checkout powered by Stripe" },
+  { value: "paypal", label: "PayPal", sublabel: "PayPal account or linked bank" },
+];
+
+export default function PaymentProviderToggle({
+  value,
+  onChange,
+  disabled = false,
+  size = "md",
+}: PaymentProviderToggleProps) {
+  const padding = size === "sm" ? "px-2.5 py-2" : "px-3 py-2.5";
+  const labelSize = size === "sm" ? "text-xs" : "text-sm";
+  const sublabelSize = size === "sm" ? "text-[10px]" : "text-[11px]";
+  const markHeight = size === "sm" ? "h-3" : "h-3.5";
+  const markHeightWide = size === "sm" ? "h-3" : "h-3.5";
+  const lockSize = size === "sm" ? 10 : 12;
+
+  return (
+    <div
+      role="radiogroup"
+      aria-label="Payment method"
+      className="grid grid-cols-2 gap-2 rounded-md border border-gray-800 bg-gray-800/20 p-1"
+    >
+      {OPTIONS.map((option) => {
+        const isActive = option.value === value;
+        return (
+          <button
+            key={option.value}
+            type="button"
+            role="radio"
+            aria-checked={isActive}
+            disabled={disabled}
+            onClick={() => onChange(option.value)}
+            className={`flex flex-col items-center justify-start gap-1 ${padding} rounded-[5px] transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40 ${
+              isActive
+                ? "bg-indigo-500/20 border border-indigo-500/30 text-indigo-100"
+                : "border border-transparent text-gray-300 hover:bg-gray-800/60"
+            }`}
+          >
+            <span className="flex items-center gap-1.5 leading-tight">
+              <ShieldCheck
+                size={lockSize}
+                strokeWidth={2.25}
+                aria-hidden="true"
+                className={isActive ? "text-indigo-300" : "text-gray-500"}
+              />
+              <span className={`${labelSize} font-semibold`}>{option.label}</span>
+            </span>
+            <span
+              className={`${sublabelSize} leading-tight text-center ${
+                isActive ? "text-indigo-200/80" : "text-gray-500"
+              }`}
+            >
+              {option.sublabel}
+            </span>
+            <span
+              aria-hidden="true"
+              className={`mt-0.5 flex items-center justify-center gap-1 transition-opacity ${
+                isActive ? "opacity-100" : "opacity-70"
+              }`}
+            >
+              {option.value === "stripe" ? (
+                <>
+                  <VisaMark className={markHeight} />
+                  <MastercardMark className={markHeight} />
+                  <AmexMark className={markHeight} />
+                </>
+              ) : (
+                <PayPalMark className={markHeightWide} />
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/support/PaymentProviderToggle.tsx
+++ b/src/components/support/PaymentProviderToggle.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { ShieldCheck } from "lucide-react";
+import { Lock } from "lucide-react";
 
 export type PaymentProvider = "stripe" | "paypal";
 
@@ -81,38 +81,27 @@ function AmexMark({ className }: { className?: string }) {
   );
 }
 
-function PayPalMark({ className }: { className?: string }) {
+function PayPalMark({ className, muted = false }: { className?: string; muted?: boolean }) {
+  const dark = muted ? "#6B7FCF" : "#003087";
+  const light = muted ? "#7BAEE6" : "#009CDE";
   return (
     <svg
-      viewBox="0 0 72 24"
+      viewBox="0 0 46 56"
       className={className}
       role="img"
       aria-label="PayPal"
     >
-      <rect width="72" height="24" rx="3" fill="#ffffff" />
-      <text
-        x="6"
-        y="17"
-        fontFamily="Arial, Helvetica, sans-serif"
-        fontWeight="900"
-        fontStyle="italic"
-        fontSize="12.5"
-      >
-        <tspan fill="#003087">Pay</tspan>
-        <tspan fill="#0070BA">Pal</tspan>
-      </text>
+      <path
+        d="M39.2 11.9c0-.1 0-.2.1-.3C37.8 5.5 32.3 2 25.3 2H10.1c-1.1 0-2 .8-2.2 1.9L2 38.3c-.1.8.5 1.5 1.3 1.5h9.5l-.7 4.3c-.1.7.4 1.3 1.1 1.3h8c.9 0 1.7-.7 1.9-1.6l.1-.4 1.5-9.5.1-.5c.2-.9.9-1.6 1.9-1.6h1.2c7.6 0 13.5-3.1 15.3-12.1.7-3.7.3-6.8-1.5-9z"
+        fill={light}
+      />
+      <path
+        d="M39.2 11.9c0-.1 0-.2.1-.3C37.8 5.5 32.3 2 25.3 2H10.1c-1.1 0-2 .8-2.2 1.9L2 38.3c-.1.8.5 1.5 1.3 1.5h9.5l2.4-15.1-.1.2c.2-1.1 1.1-1.9 2.2-1.9h4.5c8.8 0 15.7-3.6 17.7-13.9.1-.3.1-.6.2-.9-.3-.1-.3-.1 0 0 .5-3.5.0-5.8-1.5-8z"
+        fill={dark}
+      />
     </svg>
   );
 }
-
-const OPTIONS: {
-  value: PaymentProvider;
-  label: string;
-  sublabel: string;
-}[] = [
-  { value: "stripe", label: "Card", sublabel: "Secure card checkout powered by Stripe" },
-  { value: "paypal", label: "PayPal", sublabel: "PayPal account or linked bank" },
-];
 
 export default function PaymentProviderToggle({
   value,
@@ -120,70 +109,78 @@ export default function PaymentProviderToggle({
   disabled = false,
   size = "md",
 }: PaymentProviderToggleProps) {
-  const padding = size === "sm" ? "px-2.5 py-2" : "px-3 py-2.5";
-  const labelSize = size === "sm" ? "text-xs" : "text-sm";
-  const sublabelSize = size === "sm" ? "text-[10px]" : "text-[11px]";
-  const markHeight = size === "sm" ? "h-3" : "h-3.5";
-  const markHeightWide = size === "sm" ? "h-3" : "h-3.5";
-  const lockSize = size === "sm" ? 10 : 12;
+  const isSmall = size === "sm";
+  const markH = isSmall ? "h-[13px]" : "h-[15px]";
+  const paypalMarkH = isSmall ? "h-4" : "h-[18px]";
 
   return (
-    <div
-      role="radiogroup"
-      aria-label="Payment method"
-      className="grid grid-cols-2 gap-2 rounded-md border border-gray-800 bg-gray-800/20 p-1"
-    >
-      {OPTIONS.map((option) => {
-        const isActive = option.value === value;
-        return (
-          <button
-            key={option.value}
-            type="button"
-            role="radio"
-            aria-checked={isActive}
-            disabled={disabled}
-            onClick={() => onChange(option.value)}
-            className={`flex flex-col items-center justify-start gap-1 ${padding} rounded-[5px] transition-colors disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40 ${
-              isActive
-                ? "bg-indigo-500/20 border border-indigo-500/30 text-indigo-100"
-                : "border border-transparent text-gray-300 hover:bg-gray-800/60"
-            }`}
-          >
-            <span className="flex items-center gap-1.5 leading-tight">
-              <ShieldCheck
-                size={lockSize}
-                strokeWidth={2.25}
-                aria-hidden="true"
-                className={isActive ? "text-indigo-300" : "text-gray-500"}
-              />
-              <span className={`${labelSize} font-semibold`}>{option.label}</span>
-            </span>
-            <span
-              className={`${sublabelSize} leading-tight text-center ${
-                isActive ? "text-indigo-200/80" : "text-gray-500"
-              }`}
-            >
-              {option.sublabel}
-            </span>
-            <span
-              aria-hidden="true"
-              className={`mt-0.5 flex items-center justify-center gap-1 transition-opacity ${
-                isActive ? "opacity-100" : "opacity-70"
-              }`}
-            >
-              {option.value === "stripe" ? (
-                <>
-                  <VisaMark className={markHeight} />
-                  <MastercardMark className={markHeight} />
-                  <AmexMark className={markHeight} />
-                </>
-              ) : (
-                <PayPalMark className={markHeightWide} />
-              )}
-            </span>
-          </button>
-        );
-      })}
+    <div className="space-y-1.5">
+      <div className="flex items-center gap-1.5">
+        <Lock
+          size={isSmall ? 10 : 11}
+          strokeWidth={2.5}
+          className="text-gray-400"
+          aria-hidden="true"
+        />
+        <span className={`${isSmall ? "text-[10px]" : "text-[11px]"} font-medium text-gray-400 uppercase tracking-wider`}>
+          Payment method
+        </span>
+      </div>
+      <div
+        role="radiogroup"
+        aria-label="Payment method"
+        className="grid grid-cols-2 gap-2"
+      >
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === "stripe"}
+          disabled={disabled}
+          onClick={() => onChange("stripe")}
+          className={`flex items-center justify-center gap-2 rounded-md ${
+            isSmall ? "px-3 py-2" : "px-4 py-2.5"
+          } border transition-all disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40 ${
+            value === "stripe"
+              ? "border-indigo-500/40 bg-indigo-500/[0.08] ring-1 ring-indigo-500/20"
+              : "border-gray-800 bg-gray-900/40 hover:border-gray-700 hover:bg-gray-800/40"
+          }`}
+        >
+          <span className={`flex items-center gap-1 ${value === "stripe" ? "opacity-100" : "opacity-75"}`}>
+            <VisaMark className={markH} />
+            <MastercardMark className={markH} />
+            <AmexMark className={markH} />
+          </span>
+          <span className={`${isSmall ? "text-xs" : "text-sm"} font-medium ${
+            value === "stripe" ? "text-white" : "text-gray-400"
+          }`}>
+            Card
+          </span>
+        </button>
+        <button
+          type="button"
+          role="radio"
+          aria-checked={value === "paypal"}
+          disabled={disabled}
+          onClick={() => onChange("paypal")}
+          className={`flex items-center justify-center gap-2 rounded-md ${
+            isSmall ? "px-3 py-2" : "px-4 py-2.5"
+          } border transition-all disabled:opacity-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40 ${
+            value === "paypal"
+              ? "border-indigo-500/40 bg-indigo-500/[0.08] ring-1 ring-indigo-500/20"
+              : "border-gray-800 bg-gray-900/40 hover:border-gray-700 hover:bg-gray-800/40"
+          }`}
+        >
+          <PayPalMark className={`${paypalMarkH} w-auto`} muted={value !== "paypal"} />
+          <span className={`${isSmall ? "text-xs" : "text-sm"} font-medium ${
+            value === "paypal" ? "text-white" : "text-gray-400"
+          }`}>
+            PayPal
+          </span>
+        </button>
+      </div>
+      <p className={`${isSmall ? "text-[10px]" : "text-[11px]"} text-gray-500 leading-tight`}>
+        Powered by Stripe and PayPal. Payment details are never stored.
+      </p>
     </div>
   );
 }

--- a/src/server/api/billingRouteHandlers.ts
+++ b/src/server/api/billingRouteHandlers.ts
@@ -69,6 +69,7 @@ type PayPalChangePlanDeps = {
   revisePayPalSubscriptionPlan: (params: {
     paypalSubscriptionId: string;
     planId: string;
+    origin: string;
   }) => Promise<{ approveUrl: string | null }>;
   updatePendingSubscriptionPriceId: (params: {
     clerkUserId: string;
@@ -248,13 +249,15 @@ export const createPayPalSubscriptionHandler =
         return { status: 500, body: { error: "Unable to start PayPal checkout." } };
       }
 
-      await deps.recordPayPalSubscription({
-        clerkUserId,
-        paypalSubscriptionId: subscription.id,
-        paypalPayerId: subscription.payerId,
-        subscriptionStatus: subscription.status,
-        subscriptionPriceId: planId,
-      });
+      if (isActiveSubscriptionStatus(subscription.status)) {
+        await deps.recordPayPalSubscription({
+          clerkUserId,
+          paypalSubscriptionId: subscription.id,
+          paypalPayerId: subscription.payerId,
+          subscriptionStatus: subscription.status,
+          subscriptionPriceId: planId,
+        });
+      }
 
       return { status: 200, body: { url: subscription.approveUrl } };
     } catch (error) {
@@ -334,6 +337,7 @@ export const changePayPalPlanHandler =
       const result = await deps.revisePayPalSubscriptionPlan({
         paypalSubscriptionId: user.paypalSubscriptionId,
         planId,
+        origin: getRequestOrigin(input.headers),
       });
 
       await deps.updatePendingSubscriptionPriceId({

--- a/src/server/api/billingRouteHandlers.ts
+++ b/src/server/api/billingRouteHandlers.ts
@@ -1,3 +1,5 @@
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
+
 type CheckoutDeps = {
   getAuthUserId: () => Promise<string | null> | string | null;
   getPriceMap: () => Record<number, string>;
@@ -24,6 +26,73 @@ type PortalDeps = {
   }) => Promise<{ url: string }>;
 };
 
+type PayPalCheckoutDeps = {
+  getAuthUserId: () => Promise<string | null> | string | null;
+  getPlanMap: () => Record<number, string>;
+  isPayPalEnabled: () => boolean;
+  findUserByClerkId: (clerkUserId: string) => Promise<{
+    clerkUserId: string;
+    subscriptionStatus: string | null;
+  } | null>;
+  createPayPalSubscription: (params: {
+    tier: number;
+    planId: string;
+    clerkUserId: string;
+    origin: string;
+  }) => Promise<{
+    id: string;
+    status: string | null;
+    approveUrl: string | null;
+    payerId: string | null;
+  }>;
+  recordPayPalSubscription: (params: {
+    clerkUserId: string;
+    paypalSubscriptionId: string;
+    paypalPayerId: string | null;
+    subscriptionStatus: string | null;
+    subscriptionPriceId: string;
+  }) => Promise<void>;
+};
+
+type PayPalChangePlanDeps = {
+  getAuthUserId: () => Promise<string | null> | string | null;
+  getPlanMap: () => Record<number, string>;
+  isPayPalEnabled: () => boolean;
+  findUserByClerkId: (clerkUserId: string) => Promise<{
+    clerkUserId: string;
+    subscriptionProvider: "stripe" | "paypal" | null;
+    subscriptionStatus: string | null;
+    subscriptionPriceId: string | null;
+    pendingSubscriptionPriceId: string | null;
+    paypalSubscriptionId: string | null;
+  } | null>;
+  revisePayPalSubscriptionPlan: (params: {
+    paypalSubscriptionId: string;
+    planId: string;
+  }) => Promise<{ approveUrl: string | null }>;
+  updatePendingSubscriptionPriceId: (params: {
+    clerkUserId: string;
+    pendingSubscriptionPriceId: string;
+  }) => Promise<void>;
+};
+
+type PayPalCancelDeps = {
+  getAuthUserId: () => Promise<string | null> | string | null;
+  isPayPalEnabled: () => boolean;
+  findUserByClerkId: (clerkUserId: string) => Promise<{
+    clerkUserId: string;
+    subscriptionProvider: "stripe" | "paypal" | null;
+    paypalSubscriptionId: string | null;
+  } | null>;
+  cancelPayPalSubscription: (params: {
+    paypalSubscriptionId: string;
+    reason: string;
+  }) => Promise<void>;
+  markPayPalSubscriptionCancelAtPeriodEnd: (params: {
+    clerkUserId: string;
+  }) => Promise<void>;
+};
+
 type BillingRequestInput = {
   method: string;
   body: unknown;
@@ -41,9 +110,7 @@ const parseTier = (value: unknown): number | null => {
   return parsed;
 };
 
-const ACTIVE_STATUSES = new Set(["active", "trialing", "past_due"]);
-
-const getRequestOrigin = (headers: Headers): string => {
+export const getRequestOrigin = (headers: Headers): string => {
   const envBaseUrl = process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "");
   if (envBaseUrl) return envBaseUrl;
   const host = headers.get("x-forwarded-host") ?? headers.get("host");
@@ -74,7 +141,7 @@ export const createCheckoutSessionHandler =
     if (!user) {
       return { status: 404, body: { error: "User not found." } };
     }
-    if (user.subscriptionStatus && ACTIVE_STATUSES.has(user.subscriptionStatus)) {
+    if (isActiveSubscriptionStatus(user.subscriptionStatus)) {
       return {
         status: 409,
         body: {
@@ -119,6 +186,231 @@ export const createCheckoutSessionHandler =
             process.env.NODE_ENV === "development"
               ? message
               : "Unable to create checkout session.",
+        },
+      };
+    }
+  };
+
+export const createPayPalSubscriptionHandler =
+  (deps: PayPalCheckoutDeps) =>
+  async (input: BillingRequestInput): Promise<BillingResponse> => {
+    if (input.method !== "POST") {
+      return { status: 405, body: { error: "Method not allowed" } };
+    }
+
+    if (!deps.isPayPalEnabled()) {
+      return {
+        status: 404,
+        body: { error: "PayPal subscriptions are not available right now." },
+      };
+    }
+
+    const clerkUserId = await deps.getAuthUserId();
+    if (!clerkUserId) {
+      return { status: 401, body: { error: "Unauthorized" } };
+    }
+
+    const payload = input.body as { tier?: unknown } | null;
+    const tier = parseTier(payload?.tier);
+    if (!tier) {
+      return { status: 400, body: { error: "tier must be one of 1, 2, or 3." } };
+    }
+
+    const user = await deps.findUserByClerkId(clerkUserId);
+    if (!user) {
+      return { status: 404, body: { error: "User not found." } };
+    }
+
+    if (isActiveSubscriptionStatus(user.subscriptionStatus)) {
+      return {
+        status: 409,
+        body: {
+          error:
+            "You already have an active subscription. Use Billing to switch plans or manage your subscription.",
+        },
+      };
+    }
+
+    const planMap = deps.getPlanMap();
+    const planId = planMap[tier];
+    if (!planId) {
+      return { status: 500, body: { error: "PayPal pricing is misconfigured." } };
+    }
+
+    try {
+      const subscription = await deps.createPayPalSubscription({
+        tier,
+        planId,
+        clerkUserId,
+        origin: getRequestOrigin(input.headers),
+      });
+      if (!subscription.approveUrl) {
+        return { status: 500, body: { error: "Unable to start PayPal checkout." } };
+      }
+
+      await deps.recordPayPalSubscription({
+        clerkUserId,
+        paypalSubscriptionId: subscription.id,
+        paypalPayerId: subscription.payerId,
+        subscriptionStatus: subscription.status,
+        subscriptionPriceId: planId,
+      });
+
+      return { status: 200, body: { url: subscription.approveUrl } };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to create PayPal subscription.";
+      console.error("create-paypal-subscription failed:", {
+        clerkUserId,
+        tier,
+        planId,
+        message,
+      });
+      return {
+        status: 500,
+        body: {
+          error:
+            process.env.NODE_ENV === "development"
+              ? message
+              : "Unable to create PayPal subscription.",
+        },
+      };
+    }
+  };
+
+export const changePayPalPlanHandler =
+  (deps: PayPalChangePlanDeps) =>
+  async (input: BillingRequestInput): Promise<BillingResponse> => {
+    if (input.method !== "POST") {
+      return { status: 405, body: { error: "Method not allowed" } };
+    }
+
+    if (!deps.isPayPalEnabled()) {
+      return {
+        status: 404,
+        body: { error: "PayPal subscriptions are not available right now." },
+      };
+    }
+
+    const clerkUserId = await deps.getAuthUserId();
+    if (!clerkUserId) {
+      return { status: 401, body: { error: "Unauthorized" } };
+    }
+
+    const payload = input.body as { tier?: unknown } | null;
+    const tier = parseTier(payload?.tier);
+    if (!tier) {
+      return { status: 400, body: { error: "tier must be one of 1, 2, or 3." } };
+    }
+
+    const user = await deps.findUserByClerkId(clerkUserId);
+    if (!user) {
+      return { status: 404, body: { error: "User not found." } };
+    }
+    if (
+      user.subscriptionProvider !== "paypal" ||
+      !isActiveSubscriptionStatus(user.subscriptionStatus) ||
+      !user.paypalSubscriptionId
+    ) {
+      return { status: 409, body: { error: "No active PayPal subscription found." } };
+    }
+
+    const planMap = deps.getPlanMap();
+    const planId = planMap[tier];
+    if (!planId) {
+      return { status: 500, body: { error: "PayPal pricing is misconfigured." } };
+    }
+    if (planId === user.subscriptionPriceId) {
+      return { status: 409, body: { error: "You are already on that tier." } };
+    }
+    if (planId === user.pendingSubscriptionPriceId) {
+      return {
+        status: 409,
+        body: { error: "This tier is already scheduled for your next billing cycle." },
+      };
+    }
+
+    try {
+      const result = await deps.revisePayPalSubscriptionPlan({
+        paypalSubscriptionId: user.paypalSubscriptionId,
+        planId,
+      });
+
+      await deps.updatePendingSubscriptionPriceId({
+        clerkUserId,
+        pendingSubscriptionPriceId: planId,
+      });
+
+      return { status: 200, body: { url: result.approveUrl ?? `${getRequestOrigin(input.headers)}/billing?switch=scheduled` } };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to schedule PayPal plan change.";
+      console.error("change-paypal-plan failed:", {
+        clerkUserId,
+        tier,
+        planId,
+        message,
+      });
+      return {
+        status: 500,
+        body: {
+          error:
+            process.env.NODE_ENV === "development"
+              ? message
+              : "Unable to schedule PayPal plan change.",
+        },
+      };
+    }
+  };
+
+export const cancelPayPalSubscriptionHandler =
+  (deps: PayPalCancelDeps) =>
+  async (input: BillingRequestInput): Promise<BillingResponse> => {
+    if (input.method !== "POST") {
+      return { status: 405, body: { error: "Method not allowed" } };
+    }
+
+    if (!deps.isPayPalEnabled()) {
+      return {
+        status: 404,
+        body: { error: "PayPal subscriptions are not available right now." },
+      };
+    }
+
+    const clerkUserId = await deps.getAuthUserId();
+    if (!clerkUserId) {
+      return { status: 401, body: { error: "Unauthorized" } };
+    }
+
+    const user = await deps.findUserByClerkId(clerkUserId);
+    if (!user || user.subscriptionProvider !== "paypal" || !user.paypalSubscriptionId) {
+      return { status: 404, body: { error: "No PayPal subscription found." } };
+    }
+
+    try {
+      await deps.cancelPayPalSubscription({
+        paypalSubscriptionId: user.paypalSubscriptionId,
+        reason: "User requested cancellation.",
+      });
+      await deps.markPayPalSubscriptionCancelAtPeriodEnd({
+        clerkUserId,
+      });
+      return { status: 200, body: { url: `${getRequestOrigin(input.headers)}/billing` } };
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to cancel PayPal subscription.";
+      console.error("cancel-paypal-subscription failed:", {
+        clerkUserId,
+        paypalSubscriptionId: user.paypalSubscriptionId,
+        message,
+      });
+      return {
+        status: 500,
+        body: {
+          error:
+            process.env.NODE_ENV === "development"
+              ? message
+              : "Unable to cancel PayPal subscription.",
         },
       };
     }

--- a/src/server/api/paypalWebhookRouteHandler.ts
+++ b/src/server/api/paypalWebhookRouteHandler.ts
@@ -175,13 +175,22 @@ const findLinkedUser = async (
 
 const isStalePayPalEventForStripeSubscriber = (
   user: {
+    clerkUserId: string;
     subscriptionProvider?: "stripe" | "paypal" | null;
     stripeSubscriptionId?: string | null;
     paypalSubscriptionId?: string | null;
   },
-  resource: PayPalWebhookResource
+  resource: PayPalWebhookResource,
+  eventType: string | undefined
 ): boolean => {
   if (user.subscriptionProvider !== "stripe" && !user.stripeSubscriptionId) return false;
+  const eventClerkUserId =
+    typeof resource.custom_id === "string" && resource.custom_id.length > 0
+      ? resource.custom_id
+      : null;
+  if (eventType === "BILLING.SUBSCRIPTION.ACTIVATED" && eventClerkUserId === user.clerkUserId) {
+    return false;
+  }
   const eventPayPalSubscriptionId =
     typeof resource.id === "string" && resource.id.length > 0 ? resource.id : null;
   const trackedPayPalSubscriptionId = user.paypalSubscriptionId ?? null;
@@ -239,7 +248,7 @@ export const createPayPalWebhookHandler =
       if (!user) {
         return { status: 200, body: { received: true } };
       }
-      if (isStalePayPalEventForStripeSubscriber(user, resource)) {
+      if (isStalePayPalEventForStripeSubscriber(user, resource, event.event_type)) {
         return { status: 200, body: { received: true } };
       }
       if (isOutOfOrderProviderEvent(user, occurredAt)) {
@@ -249,6 +258,14 @@ export const createPayPalWebhookHandler =
       const internalStatus = toInternalStatus(resource.status);
       const isActive = isActiveSubscriptionStatus(internalStatus);
       const cancelAtPeriodEnd = internalStatus === "canceled";
+      const eventPayPalSubscriptionId =
+        typeof resource.id === "string" && resource.id.length > 0 ? resource.id : null;
+      const hasTrackedPayPalState =
+        user.subscriptionProvider === "paypal" ||
+        (Boolean(user.paypalSubscriptionId) && user.paypalSubscriptionId === eventPayPalSubscriptionId);
+      if (internalStatus === "incomplete" && !hasTrackedPayPalState) {
+        return { status: 200, body: { received: true } };
+      }
       const planId = typeof resource.plan_id === "string" ? resource.plan_id : null;
       const supporterTier =
         internalStatus && deps.shouldGrantSupporterBadge(internalStatus)

--- a/src/server/api/paypalWebhookRouteHandler.ts
+++ b/src/server/api/paypalWebhookRouteHandler.ts
@@ -123,6 +123,16 @@ const toDate = (iso: string | undefined): Date | null => {
   return parsed;
 };
 
+const hasFutureGraceAccess = (params: {
+  cancelAtPeriodEnd: boolean;
+  periodEnd: Date | null;
+  now?: Date;
+}): boolean => {
+  if (!params.cancelAtPeriodEnd || !params.periodEnd) return false;
+  const now = params.now ?? new Date();
+  return params.periodEnd.getTime() > now.getTime();
+};
+
 const resolveEventOccurredAt = (
   event: PayPalWebhookEvent,
   transmissionTime: string
@@ -290,8 +300,12 @@ export const createPayPalWebhookHandler =
       const nextPendingSubscriptionPriceId =
         shouldPromotePendingPlan || !isActive ? null : user.pendingSubscriptionPriceId;
       const nextPeriodEnd = nextBillingTime ?? user.subscriptionCurrentPeriodEnd ?? null;
+      const nextHasGraceAccess = hasFutureGraceAccess({
+        cancelAtPeriodEnd,
+        periodEnd: nextPeriodEnd,
+      });
       const nextSupporterTier =
-        internalStatus && deps.shouldGrantSupporterBadge(internalStatus)
+        (internalStatus && deps.shouldGrantSupporterBadge(internalStatus)) || nextHasGraceAccess
           ? getTierFromPlanId(nextSubscriptionPriceId, deps.getPlanMap())
           : 0;
       await deps.updateUserSubscription(user.clerkUserId, {

--- a/src/server/api/paypalWebhookRouteHandler.ts
+++ b/src/server/api/paypalWebhookRouteHandler.ts
@@ -1,0 +1,300 @@
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
+
+type PayPalWebhookResource = {
+  id?: string;
+  status?: string;
+  custom_id?: string;
+  plan_id?: string;
+  subscriber?: {
+    payer_id?: string;
+  };
+  billing_info?: {
+    next_billing_time?: string;
+  };
+};
+
+type PayPalWebhookEvent = {
+  id?: string;
+  create_time?: string;
+  event_type?: string;
+  resource?: PayPalWebhookResource;
+};
+
+type PayPalWebhookDeps = {
+  markEventProcessed: (externalEventId: string) => Promise<boolean>;
+  unmarkEventProcessed: (externalEventId: string) => Promise<void>;
+  verifyWebhook: (params: {
+    transmissionId: string;
+    transmissionTime: string;
+    transmissionSig: string;
+    certUrl: string;
+    authAlgo: string;
+    webhookEvent: Record<string, unknown>;
+  }) => Promise<boolean>;
+  getPlanMap: () => Record<number, string>;
+  shouldGrantSupporterBadge: (status: string) => boolean;
+  findUserByClerkUserId: (clerkUserId: string) => Promise<{
+    clerkUserId: string;
+    subscriptionProvider?: "stripe" | "paypal" | null;
+    subscriptionProviderUpdatedAt?: Date | null;
+    stripeSubscriptionId?: string | null;
+    paypalSubscriptionId?: string | null;
+    subscriptionPriceId: string | null;
+    pendingSubscriptionPriceId: string | null;
+    subscriptionCurrentPeriodEnd?: Date | null;
+  } | null>;
+  findUserByPayPalSubscriptionId: (
+    paypalSubscriptionId: string
+  ) => Promise<{
+    clerkUserId: string;
+    subscriptionProvider?: "stripe" | "paypal" | null;
+    subscriptionProviderUpdatedAt?: Date | null;
+    stripeSubscriptionId?: string | null;
+    paypalSubscriptionId?: string | null;
+    subscriptionPriceId: string | null;
+    pendingSubscriptionPriceId: string | null;
+    subscriptionCurrentPeriodEnd?: Date | null;
+  } | null>;
+  findUserByPayPalPayerId: (paypalPayerId: string) => Promise<{
+    clerkUserId: string;
+    subscriptionProvider?: "stripe" | "paypal" | null;
+    subscriptionProviderUpdatedAt?: Date | null;
+    stripeSubscriptionId?: string | null;
+    paypalSubscriptionId?: string | null;
+    subscriptionPriceId: string | null;
+    pendingSubscriptionPriceId: string | null;
+    subscriptionCurrentPeriodEnd?: Date | null;
+  } | null>;
+  updateUserSubscription: (
+    clerkUserId: string,
+    data: {
+      subscriptionProvider?: "stripe" | "paypal" | null;
+      stripeCustomerId?: string | null;
+      stripeSubscriptionId?: string | null;
+      paypalPayerId?: string | null;
+      paypalSubscriptionId?: string | null;
+      pendingSubscriptionPriceId?: string | null;
+      subscriptionProviderUpdatedAt?: Date | null;
+      subscriptionStatus?: string | null;
+      subscriptionPriceId?: string | null;
+      subscriptionCurrentPeriodEnd?: Date | null;
+      subscriptionCancelAtPeriodEnd?: boolean;
+      supporterTier?: number;
+    }
+  ) => Promise<void>;
+};
+
+export type PayPalWebhookInput = {
+  method: string;
+  headers: Headers;
+  body: Record<string, unknown>;
+};
+
+export type PayPalWebhookResponse = {
+  status: number;
+  body: { error: string } | { received: true; duplicate?: true };
+};
+
+const STATUS_MAP: Record<string, string> = {
+  ACTIVE: "active",
+  SUSPENDED: "past_due",
+  CANCELLED: "canceled",
+  EXPIRED: "canceled",
+  APPROVAL_PENDING: "incomplete",
+  APPROVED: "incomplete",
+};
+
+const toInternalStatus = (status: string | undefined): string | null => {
+  if (!status) return null;
+  return STATUS_MAP[status] ?? status.toLowerCase();
+};
+
+const getTierFromPlanId = (planId: string | null, planMap: Record<number, string>): number => {
+  if (!planId) return 0;
+  const match = Object.entries(planMap).find(([, value]) => value === planId);
+  if (!match) return 0;
+  return Number(match[0]);
+};
+
+const toDate = (iso: string | undefined): Date | null => {
+  if (!iso) return null;
+  const parsed = new Date(iso);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return parsed;
+};
+
+const resolveEventOccurredAt = (
+  event: PayPalWebhookEvent,
+  transmissionTime: string
+): Date | null => {
+  return toDate(event.create_time) ?? toDate(transmissionTime);
+};
+
+const extractVerificationHeaders = (headers: Headers) => {
+  const transmissionId = headers.get("paypal-transmission-id");
+  const transmissionTime = headers.get("paypal-transmission-time");
+  const transmissionSig = headers.get("paypal-transmission-sig");
+  const certUrl = headers.get("paypal-cert-url");
+  const authAlgo = headers.get("paypal-auth-algo");
+  if (!transmissionId || !transmissionTime || !transmissionSig || !certUrl || !authAlgo) {
+    return null;
+  }
+  return { transmissionId, transmissionTime, transmissionSig, certUrl, authAlgo };
+};
+
+const findLinkedUser = async (
+  resource: PayPalWebhookResource,
+  deps: PayPalWebhookDeps
+): Promise<{
+  clerkUserId: string;
+  subscriptionProvider?: "stripe" | "paypal" | null;
+  subscriptionProviderUpdatedAt?: Date | null;
+  stripeSubscriptionId?: string | null;
+  paypalSubscriptionId?: string | null;
+  subscriptionPriceId: string | null;
+  pendingSubscriptionPriceId: string | null;
+  subscriptionCurrentPeriodEnd?: Date | null;
+} | null> => {
+  const clerkUserId = resource.custom_id;
+  if (typeof clerkUserId === "string" && clerkUserId.length > 0) {
+    const user = await deps.findUserByClerkUserId(clerkUserId);
+    if (user) return user;
+  }
+  const paypalSubscriptionId = resource.id;
+  if (typeof paypalSubscriptionId === "string" && paypalSubscriptionId.length > 0) {
+    const user = await deps.findUserByPayPalSubscriptionId(paypalSubscriptionId);
+    if (user) return user;
+  }
+  const payerId = resource.subscriber?.payer_id;
+  if (typeof payerId === "string" && payerId.length > 0) {
+    const user = await deps.findUserByPayPalPayerId(payerId);
+    if (user) return user;
+  }
+  return null;
+};
+
+const isStalePayPalEventForStripeSubscriber = (
+  user: {
+    subscriptionProvider?: "stripe" | "paypal" | null;
+    stripeSubscriptionId?: string | null;
+    paypalSubscriptionId?: string | null;
+  },
+  resource: PayPalWebhookResource
+): boolean => {
+  if (user.subscriptionProvider !== "stripe" && !user.stripeSubscriptionId) return false;
+  const eventPayPalSubscriptionId =
+    typeof resource.id === "string" && resource.id.length > 0 ? resource.id : null;
+  const trackedPayPalSubscriptionId = user.paypalSubscriptionId ?? null;
+  if (trackedPayPalSubscriptionId && trackedPayPalSubscriptionId === eventPayPalSubscriptionId) {
+    return false;
+  }
+  return true;
+};
+
+const isOutOfOrderProviderEvent = (
+  user: {
+    subscriptionProviderUpdatedAt?: Date | null;
+  },
+  occurredAt: Date | null
+): boolean => {
+  if (!occurredAt || !user.subscriptionProviderUpdatedAt) return false;
+  return occurredAt.getTime() < user.subscriptionProviderUpdatedAt.getTime();
+};
+
+export const createPayPalWebhookHandler =
+  (deps: PayPalWebhookDeps) =>
+  async (input: PayPalWebhookInput): Promise<PayPalWebhookResponse> => {
+    if (input.method !== "POST") {
+      return { status: 405, body: { error: "Method not allowed" } };
+    }
+
+    const verificationHeaders = extractVerificationHeaders(input.headers);
+    if (!verificationHeaders) {
+      return { status: 400, body: { error: "Missing PayPal verification headers." } };
+    }
+
+    const event = input.body as PayPalWebhookEvent;
+    const eventId = typeof event.id === "string" && event.id.length > 0 ? event.id : null;
+    if (!eventId) {
+      return { status: 400, body: { error: "Missing PayPal webhook event id." } };
+    }
+
+    const isValid = await deps.verifyWebhook({
+      ...verificationHeaders,
+      webhookEvent: input.body,
+    });
+    if (!isValid) {
+      return { status: 401, body: { error: "Invalid PayPal webhook signature." } };
+    }
+
+    const wasMarked = await deps.markEventProcessed(eventId);
+    if (!wasMarked) {
+      return { status: 200, body: { received: true, duplicate: true } };
+    }
+
+    try {
+      const occurredAt = resolveEventOccurredAt(event, verificationHeaders.transmissionTime);
+      const resource = event.resource ?? {};
+      const user = await findLinkedUser(resource, deps);
+      if (!user) {
+        return { status: 200, body: { received: true } };
+      }
+      if (isStalePayPalEventForStripeSubscriber(user, resource)) {
+        return { status: 200, body: { received: true } };
+      }
+      if (isOutOfOrderProviderEvent(user, occurredAt)) {
+        return { status: 200, body: { received: true } };
+      }
+
+      const internalStatus = toInternalStatus(resource.status);
+      const isActive = isActiveSubscriptionStatus(internalStatus);
+      const cancelAtPeriodEnd = internalStatus === "canceled";
+      const planId = typeof resource.plan_id === "string" ? resource.plan_id : null;
+      const supporterTier =
+        internalStatus && deps.shouldGrantSupporterBadge(internalStatus)
+          ? getTierFromPlanId(planId, deps.getPlanMap())
+          : 0;
+      const paypalSubscriptionId = typeof resource.id === "string" ? resource.id : null;
+      const paypalPayerId =
+        typeof resource.subscriber?.payer_id === "string" ? resource.subscriber.payer_id : null;
+      const nextBillingTime = toDate(resource.billing_info?.next_billing_time);
+      const hasPendingPlanChange = Boolean(user.pendingSubscriptionPriceId);
+      const isPendingPlanNowActive =
+        Boolean(user.pendingSubscriptionPriceId) && planId === user.pendingSubscriptionPriceId;
+      const shouldPromotePendingPlan =
+        isPendingPlanNowActive &&
+        (event.event_type === "BILLING.SUBSCRIPTION.PAYMENT.COMPLETED" ||
+          event.event_type === "PAYMENT.SALE.COMPLETED" ||
+          event.event_type === "BILLING.SUBSCRIPTION.ACTIVATED");
+      const nextSubscriptionPriceId =
+        hasPendingPlanChange && !shouldPromotePendingPlan
+          ? user.subscriptionPriceId
+          : planId;
+      const nextPendingSubscriptionPriceId =
+        shouldPromotePendingPlan || !isActive ? null : user.pendingSubscriptionPriceId;
+      const nextPeriodEnd = nextBillingTime ?? user.subscriptionCurrentPeriodEnd ?? null;
+      const nextSupporterTier =
+        internalStatus && deps.shouldGrantSupporterBadge(internalStatus)
+          ? getTierFromPlanId(nextSubscriptionPriceId, deps.getPlanMap())
+          : 0;
+      await deps.updateUserSubscription(user.clerkUserId, {
+        subscriptionProvider: "paypal",
+        subscriptionProviderUpdatedAt: occurredAt ?? new Date(),
+        stripeCustomerId: null,
+        stripeSubscriptionId: null,
+        paypalSubscriptionId,
+        paypalPayerId,
+        subscriptionStatus: internalStatus,
+        subscriptionPriceId: nextSubscriptionPriceId,
+        pendingSubscriptionPriceId: nextPendingSubscriptionPriceId,
+        subscriptionCurrentPeriodEnd: nextPeriodEnd,
+        subscriptionCancelAtPeriodEnd: cancelAtPeriodEnd,
+        supporterTier: nextSupporterTier,
+      });
+    } catch {
+      await deps.unmarkEventProcessed(eventId);
+      return { status: 500, body: { error: "Failed to process PayPal webhook event." } };
+    }
+
+    return { status: 200, body: { received: true } };
+  };

--- a/src/server/api/stripeWebhookRouteHandler.ts
+++ b/src/server/api/stripeWebhookRouteHandler.ts
@@ -2,6 +2,10 @@ import type Stripe from "stripe";
 
 type StripeUser = {
   clerkUserId: string;
+  subscriptionProvider?: "stripe" | "paypal" | null;
+  subscriptionProviderUpdatedAt?: Date | null;
+  stripeSubscriptionId?: string | null;
+  paypalSubscriptionId?: string | null;
 };
 
 type StripeWebhookDeps = {
@@ -15,8 +19,13 @@ type StripeWebhookDeps = {
   updateUserSubscription: (
     clerkUserId: string,
     data: {
+      subscriptionProvider?: "stripe" | "paypal" | null;
       stripeCustomerId?: string | null;
       stripeSubscriptionId?: string | null;
+      paypalPayerId?: string | null;
+      paypalSubscriptionId?: string | null;
+      pendingSubscriptionPriceId?: string | null;
+      subscriptionProviderUpdatedAt?: Date | null;
       subscriptionStatus?: string | null;
       subscriptionPriceId?: string | null;
       subscriptionCurrentPeriodEnd?: Date | null;
@@ -80,8 +89,24 @@ const resolveSubscriptionPeriodEndSeconds = (
   return null;
 };
 
+const isStaleStripeSubscriptionEventForPayPalSubscriber = (
+  user: StripeUser,
+  subscription: Stripe.Subscription
+): boolean => {
+  if (user.subscriptionProvider !== "paypal" && !user.paypalSubscriptionId) return false;
+  const trackedStripeSubscriptionId = user.stripeSubscriptionId ?? null;
+  if (trackedStripeSubscriptionId && trackedStripeSubscriptionId === subscription.id) return false;
+  return true;
+};
+
+const isOutOfOrderProviderEvent = (user: StripeUser, occurredAt: Date | null): boolean => {
+  if (!occurredAt || !user.subscriptionProviderUpdatedAt) return false;
+  return occurredAt.getTime() < user.subscriptionProviderUpdatedAt.getTime();
+};
+
 const syncFromSubscription = async (
   subscription: Stripe.Subscription,
+  occurredAt: Date | null,
   deps: StripeWebhookDeps
 ) => {
   const customerId = resolveCustomerId(subscription.customer);
@@ -96,14 +121,26 @@ const syncFromSubscription = async (
 
   if (!user) return;
 
+  if (isStaleStripeSubscriptionEventForPayPalSubscriber(user, subscription)) {
+    return;
+  }
+  if (isOutOfOrderProviderEvent(user, occurredAt)) {
+    return;
+  }
+
   const priceId = deps.extractRecurringPriceId(subscription);
   const tier = deps.shouldGrantSupporterBadge(subscription.status)
     ? deps.getTierFromPriceId(priceId, deps.getPriceMap())
     : 0;
 
   await deps.updateUserSubscription(user.clerkUserId, {
+    subscriptionProvider: "stripe",
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscription.id,
+    paypalPayerId: null,
+    paypalSubscriptionId: null,
+    pendingSubscriptionPriceId: null,
+    subscriptionProviderUpdatedAt: occurredAt ?? new Date(),
     subscriptionStatus: subscription.status,
     subscriptionPriceId: priceId,
     subscriptionCurrentPeriodEnd: toDateFromUnixSeconds(
@@ -118,6 +155,7 @@ const syncFromSubscription = async (
 
 const syncFromCheckoutSessionCompleted = async (
   session: Stripe.Checkout.Session,
+  occurredAt: Date | null,
   deps: StripeWebhookDeps
 ) => {
   if (session.mode !== "subscription") return;
@@ -127,13 +165,21 @@ const syncFromCheckoutSessionCompleted = async (
   const customerId = resolveCustomerId(session.customer);
   const subscriptionId = resolveSubscriptionId(session.subscription);
 
-  if (!clerkUserId || !customerId) return;
+  if (!clerkUserId || !customerId || !subscriptionId) return;
   const user = await deps.findUserByClerkUserId(clerkUserId);
   if (!user) return;
+  if (isOutOfOrderProviderEvent(user, occurredAt)) {
+    return;
+  }
 
   await deps.updateUserSubscription(clerkUserId, {
+    subscriptionProvider: "stripe",
+    subscriptionProviderUpdatedAt: occurredAt ?? new Date(),
     stripeCustomerId: customerId,
     stripeSubscriptionId: subscriptionId,
+    paypalPayerId: null,
+    paypalSubscriptionId: null,
+    pendingSubscriptionPriceId: null,
   });
 };
 
@@ -161,15 +207,20 @@ export const createStripeWebhookHandler =
     }
 
     try {
+      const occurredAt = toDateFromUnixSeconds(event.created);
       if (event.type === "checkout.session.completed") {
-        await syncFromCheckoutSessionCompleted(event.data.object as Stripe.Checkout.Session, deps);
+        await syncFromCheckoutSessionCompleted(
+          event.data.object as Stripe.Checkout.Session,
+          occurredAt,
+          deps
+        );
       } else if (
         event.type === "customer.subscription.created" ||
         event.type === "customer.subscription.updated"
       ) {
-        await syncFromSubscription(event.data.object as Stripe.Subscription, deps);
+        await syncFromSubscription(event.data.object as Stripe.Subscription, occurredAt, deps);
       } else if (event.type === "customer.subscription.deleted") {
-        await syncFromSubscription(event.data.object as Stripe.Subscription, deps);
+        await syncFromSubscription(event.data.object as Stripe.Subscription, occurredAt, deps);
       }
     } catch {
       await deps.unmarkEventProcessed(event.id);

--- a/src/server/billing/paypal.ts
+++ b/src/server/billing/paypal.ts
@@ -1,0 +1,261 @@
+const requiredEnv = (key: string): string => {
+  const value = process.env[key];
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${key}`);
+  }
+  return value;
+};
+
+const PAYPAL_STATUS_TO_INTERNAL: Record<string, string> = {
+  ACTIVE: "active",
+  SUSPENDED: "past_due",
+  CANCELLED: "canceled",
+  EXPIRED: "canceled",
+  APPROVAL_PENDING: "incomplete",
+  APPROVED: "incomplete",
+};
+
+export type PayPalSubscription = {
+  id: string;
+  status: string | null;
+  planId: string | null;
+  payerId: string | null;
+  nextBillingTime: string | null;
+  cancelAtPeriodEnd: boolean;
+  approveUrl: string | null;
+  manageUrl: string | null;
+};
+
+type PayPalAccessTokenResponse = {
+  access_token: string;
+};
+
+type PayPalCreateSubscriptionResponse = {
+  id: string;
+  status?: string;
+  plan_id?: string;
+  subscriber?: {
+    payer_id?: string;
+  };
+  billing_info?: {
+    next_billing_time?: string;
+  };
+  links?: Array<{
+    rel?: string;
+    href?: string;
+  }>;
+};
+
+type PayPalWebhookVerificationResponse = {
+  verification_status?: string;
+};
+
+const getPayPalBaseUrl = (): string => {
+  const explicitBaseUrl = process.env.PAYPAL_BASE_URL?.trim();
+  if (explicitBaseUrl) {
+    return explicitBaseUrl.replace(/\/$/, "");
+  }
+  const mode = (process.env.PAYPAL_ENV ?? "live").toLowerCase();
+  if (mode === "sandbox") {
+    return "https://api-m.sandbox.paypal.com";
+  }
+  return "https://api-m.paypal.com";
+};
+
+export const isPayPalSubscriptionsEnabled = (): boolean =>
+  process.env.PAYPAL_SUBSCRIPTIONS_ENABLED === "true";
+
+export const getPayPalWebhookId = (): string => requiredEnv("PAYPAL_WEBHOOK_ID");
+
+export const getPayPalPlanMap = (): Record<number, string> => ({
+  1: requiredEnv("PAYPAL_PLAN_ID_TIER_1"),
+  2: requiredEnv("PAYPAL_PLAN_ID_TIER_2"),
+  3: requiredEnv("PAYPAL_PLAN_ID_TIER_3"),
+});
+
+const parseLink = (
+  links: Array<{ rel?: string; href?: string }> | undefined,
+  rel: string
+): string | null => {
+  const link = links?.find((entry) => entry.rel === rel);
+  return typeof link?.href === "string" ? link.href : null;
+};
+
+const toInternalStatus = (paypalStatus: string | null | undefined): string | null => {
+  if (!paypalStatus) return null;
+  return PAYPAL_STATUS_TO_INTERNAL[paypalStatus] ?? paypalStatus.toLowerCase();
+};
+
+const toPayPalSubscription = (
+  payload: PayPalCreateSubscriptionResponse,
+  fallbackPlanId: string | null
+): PayPalSubscription => ({
+  id: payload.id,
+  status: toInternalStatus(payload.status),
+  planId: payload.plan_id ?? fallbackPlanId,
+  payerId: payload.subscriber?.payer_id ?? null,
+  nextBillingTime: payload.billing_info?.next_billing_time ?? null,
+  cancelAtPeriodEnd: payload.status === "CANCELLED" || payload.status === "EXPIRED",
+  approveUrl: parseLink(payload.links, "approve"),
+  manageUrl: parseLink(payload.links, "self"),
+});
+
+const getPayPalAccessToken = async (): Promise<string> => {
+  const clientId = requiredEnv("PAYPAL_CLIENT_ID");
+  const clientSecret = requiredEnv("PAYPAL_CLIENT_SECRET");
+  const response = await fetch(`${getPayPalBaseUrl()}/v1/oauth2/token`, {
+    method: "POST",
+    headers: {
+      Authorization: `Basic ${Buffer.from(`${clientId}:${clientSecret}`).toString("base64")}`,
+      "Content-Type": "application/x-www-form-urlencoded",
+    },
+    body: "grant_type=client_credentials",
+  });
+  if (!response.ok) {
+    throw new Error(`PayPal auth failed with status ${response.status}.`);
+  }
+  const payload = (await response.json()) as PayPalAccessTokenResponse;
+  if (!payload.access_token) {
+    throw new Error("PayPal auth response missing access token.");
+  }
+  return payload.access_token;
+};
+
+export const createPayPalSubscription = async (params: {
+  planId: string;
+  clerkUserId: string;
+  tier: number;
+  origin: string;
+}): Promise<PayPalSubscription> => {
+  const accessToken = await getPayPalAccessToken();
+  const response = await fetch(`${getPayPalBaseUrl()}/v1/billing/subscriptions`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+      "PayPal-Request-Id": `divoxutils-${params.clerkUserId}-${Date.now()}`,
+    },
+    body: JSON.stringify({
+      plan_id: params.planId,
+      custom_id: params.clerkUserId,
+      application_context: {
+        brand_name: "divoxutils",
+        user_action: "SUBSCRIBE_NOW",
+        return_url: `${params.origin}/billing?checkout=success&provider=paypal`,
+        cancel_url: `${params.origin}/billing?checkout=cancel&provider=paypal`,
+      },
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`PayPal subscription creation failed with status ${response.status}.`);
+  }
+  const payload = (await response.json()) as PayPalCreateSubscriptionResponse;
+  if (!payload.id) {
+    throw new Error("PayPal subscription creation did not return an id.");
+  }
+  return toPayPalSubscription(payload, params.planId);
+};
+
+export const fetchPayPalSubscription = async (
+  paypalSubscriptionId: string
+): Promise<PayPalSubscription> => {
+  const accessToken = await getPayPalAccessToken();
+  const response = await fetch(
+    `${getPayPalBaseUrl()}/v1/billing/subscriptions/${paypalSubscriptionId}`,
+    {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`PayPal subscription lookup failed with status ${response.status}.`);
+  }
+  const payload = (await response.json()) as PayPalCreateSubscriptionResponse;
+  if (!payload.id) {
+    throw new Error("PayPal subscription lookup did not return an id.");
+  }
+  return toPayPalSubscription(payload, payload.plan_id ?? null);
+};
+
+export const cancelPayPalSubscription = async (
+  paypalSubscriptionId: string,
+  reason: string
+): Promise<void> => {
+  const accessToken = await getPayPalAccessToken();
+  const response = await fetch(
+    `${getPayPalBaseUrl()}/v1/billing/subscriptions/${paypalSubscriptionId}/cancel`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ reason }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`PayPal subscription cancel failed with status ${response.status}.`);
+  }
+};
+
+export const revisePayPalSubscriptionPlan = async (params: {
+  paypalSubscriptionId: string;
+  planId: string;
+}): Promise<{ approveUrl: string | null }> => {
+  const accessToken = await getPayPalAccessToken();
+  const response = await fetch(
+    `${getPayPalBaseUrl()}/v1/billing/subscriptions/${params.paypalSubscriptionId}/revise`,
+    {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        plan_id: params.planId,
+      }),
+    }
+  );
+  if (!response.ok) {
+    throw new Error(`PayPal subscription revise failed with status ${response.status}.`);
+  }
+  const payload = (await response.json()) as {
+    links?: Array<{ rel?: string; href?: string }>;
+  };
+  return {
+    approveUrl: parseLink(payload.links, "approve"),
+  };
+};
+
+export const verifyPayPalWebhook = async (params: {
+  transmissionId: string;
+  transmissionTime: string;
+  transmissionSig: string;
+  certUrl: string;
+  authAlgo: string;
+  webhookEvent: Record<string, unknown>;
+}): Promise<boolean> => {
+  const accessToken = await getPayPalAccessToken();
+  const response = await fetch(`${getPayPalBaseUrl()}/v1/notifications/verify-webhook-signature`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      auth_algo: params.authAlgo,
+      cert_url: params.certUrl,
+      transmission_id: params.transmissionId,
+      transmission_sig: params.transmissionSig,
+      transmission_time: params.transmissionTime,
+      webhook_id: getPayPalWebhookId(),
+      webhook_event: params.webhookEvent,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error(`PayPal webhook verification failed with status ${response.status}.`);
+  }
+  const payload = (await response.json()) as PayPalWebhookVerificationResponse;
+  return payload.verification_status === "SUCCESS";
+};

--- a/src/server/billing/paypal.ts
+++ b/src/server/billing/paypal.ts
@@ -128,6 +128,7 @@ export const createPayPalSubscription = async (params: {
   origin: string;
 }): Promise<PayPalSubscription> => {
   const accessToken = await getPayPalAccessToken();
+  const billingReturnSessionId = `pp_${params.clerkUserId}_${Date.now()}`;
   const response = await fetch(`${getPayPalBaseUrl()}/v1/billing/subscriptions`, {
     method: "POST",
     headers: {
@@ -141,8 +142,8 @@ export const createPayPalSubscription = async (params: {
       application_context: {
         brand_name: "divoxutils",
         user_action: "SUBSCRIBE_NOW",
-        return_url: `${params.origin}/billing?checkout=success&provider=paypal`,
-        cancel_url: `${params.origin}/billing?checkout=cancel&provider=paypal`,
+        return_url: `${params.origin}/billing?checkout=success&provider=paypal&session_id=${encodeURIComponent(billingReturnSessionId)}`,
+        cancel_url: `${params.origin}/billing?checkout=cancel&provider=paypal&session_id=${encodeURIComponent(billingReturnSessionId)}`,
       },
     }),
   });
@@ -202,6 +203,7 @@ export const cancelPayPalSubscription = async (
 export const revisePayPalSubscriptionPlan = async (params: {
   paypalSubscriptionId: string;
   planId: string;
+  origin: string;
 }): Promise<{ approveUrl: string | null }> => {
   const accessToken = await getPayPalAccessToken();
   const response = await fetch(
@@ -214,6 +216,11 @@ export const revisePayPalSubscriptionPlan = async (params: {
       },
       body: JSON.stringify({
         plan_id: params.planId,
+        application_context: {
+          brand_name: "divoxutils",
+          return_url: `${params.origin}/billing?switch=scheduled&provider=paypal`,
+          cancel_url: `${params.origin}/billing?switch=cancel&provider=paypal`,
+        },
       }),
     }
   );

--- a/src/server/billing/stripe.ts
+++ b/src/server/billing/stripe.ts
@@ -1,10 +1,5 @@
 import Stripe from "stripe";
-
-export const ACTIVE_SUBSCRIPTION_STATUSES = new Set<Stripe.Subscription.Status>([
-  "active",
-  "trialing",
-  "past_due",
-]);
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
 
 const requiredEnv = (key: string): string => {
   const value = process.env[key];
@@ -49,10 +44,7 @@ export const getTierFromPriceId = (
 export const shouldGrantSupporterBadge = (
   subscriptionStatus: Stripe.Subscription.Status | string | null | undefined
 ): boolean => {
-  if (!subscriptionStatus) return false;
-  return ACTIVE_SUBSCRIPTION_STATUSES.has(
-    subscriptionStatus as Stripe.Subscription.Status
-  );
+  return isActiveSubscriptionStatus(subscriptionStatus);
 };
 
 export const extractRecurringPriceId = (

--- a/src/server/billing/subscriptionStatus.ts
+++ b/src/server/billing/subscriptionStatus.ts
@@ -1,0 +1,8 @@
+export const ACTIVE_SUBSCRIPTION_STATUSES = new Set(["active", "trialing", "past_due"]);
+
+export const isActiveSubscriptionStatus = (
+  subscriptionStatus: string | null | undefined
+): boolean => {
+  if (!subscriptionStatus) return false;
+  return ACTIVE_SUBSCRIPTION_STATUSES.has(subscriptionStatus);
+};

--- a/src/server/supporterStatus.ts
+++ b/src/server/supporterStatus.ts
@@ -1,3 +1,5 @@
+import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
+
 type SupporterStatusInput = {
   supporterTier?: number | null;
   subscriptionStatus?: string | null;
@@ -11,10 +13,7 @@ export function isEffectivelySupporter(
 ) {
   if (!input) return false;
   const hasTier = (input.supporterTier ?? 0) > 0;
-  const hasActiveStatus =
-    input.subscriptionStatus === "active" ||
-    input.subscriptionStatus === "trialing" ||
-    input.subscriptionStatus === "past_due";
+  const hasActiveStatus = isActiveSubscriptionStatus(input.subscriptionStatus);
   const hasGraceAccess =
     Boolean(input.subscriptionCancelAtPeriodEnd) &&
     Boolean(input.subscriptionCurrentPeriodEnd) &&

--- a/tests/billing.api.test.ts
+++ b/tests/billing.api.test.ts
@@ -225,6 +225,7 @@ test("create paypal subscription enforces feature flag", async () => {
 
 test("create paypal subscription returns approval URL", async () => {
   let recorded: Record<string, unknown> | null = null;
+  let recordCalls = 0;
   let receivedOrigin = "";
   const handler = createPayPalSubscriptionHandler({
     getAuthUserId: async () => "user_1",
@@ -241,6 +242,7 @@ test("create paypal subscription returns approval URL", async () => {
       };
     },
     recordPayPalSubscription: async (params) => {
+      recordCalls += 1;
       recorded = params as unknown as Record<string, unknown>;
     },
   });
@@ -255,7 +257,39 @@ test("create paypal subscription returns approval URL", async () => {
   assert.equal(result.status, 200);
   assert.equal((result.body as { url: string }).url, "https://paypal.test/approve");
   assert.equal(receivedOrigin, expectedOrigin);
-  assert.equal(recorded?.["subscriptionPriceId"], "plan_2");
+  assert.equal(recordCalls, 0);
+  assert.equal(recorded, null);
+});
+
+test("create paypal subscription does not overwrite stripe grace-period state before approval", async () => {
+  let recorded: Record<string, unknown> | null = null;
+  let recordCalls = 0;
+  const handler = createPayPalSubscriptionHandler({
+    getAuthUserId: async () => "user_grace",
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({ clerkUserId: "user_grace", subscriptionStatus: "canceled" }),
+    createPayPalSubscription: async () => ({
+      id: "I-SUB-PENDING",
+      status: "incomplete",
+      approveUrl: "https://paypal.test/approve",
+      payerId: "payer_grace",
+    }),
+    recordPayPalSubscription: async (params) => {
+      recordCalls += 1;
+      recorded = params as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    body: { tier: 2 },
+    headers: createHeaders(),
+  });
+  assert.equal(result.status, 200);
+  assert.equal((result.body as { url: string }).url, "https://paypal.test/approve");
+  assert.equal(recordCalls, 0);
+  assert.equal(recorded, null);
 });
 
 test("create paypal subscription blocks duplicate active subscriptions", async () => {
@@ -387,6 +421,7 @@ test("cancel paypal subscription enforces method, feature flag, and auth", async
 
 test("change paypal plan schedules pending tier and returns approval url", async () => {
   let revisedPlanId = "";
+  let revisedOrigin = "";
   let updatedPendingPlanId = "";
   const handler = changePayPalPlanHandler({
     getAuthUserId: async () => "user_1",
@@ -400,8 +435,9 @@ test("change paypal plan schedules pending tier and returns approval url", async
       pendingSubscriptionPriceId: null,
       paypalSubscriptionId: "I-SUB",
     }),
-    revisePayPalSubscriptionPlan: async ({ planId }) => {
+    revisePayPalSubscriptionPlan: async ({ planId, origin }) => {
       revisedPlanId = planId;
+      revisedOrigin = origin;
       return { approveUrl: "https://paypal.test/reapprove" };
     },
     updatePendingSubscriptionPriceId: async ({ pendingSubscriptionPriceId }) => {
@@ -416,6 +452,9 @@ test("change paypal plan schedules pending tier and returns approval url", async
   assert.equal(result.status, 200);
   assert.equal((result.body as { url: string }).url, "https://paypal.test/reapprove");
   assert.equal(revisedPlanId, "plan_3");
+  const expectedOrigin =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "https://example.com";
+  assert.equal(revisedOrigin, expectedOrigin);
   assert.equal(updatedPendingPlanId, "plan_3");
 });
 
@@ -1044,7 +1083,7 @@ test("paypal webhook updates subscription state", async () => {
   assert.equal(updatedData?.["supporterTier"], 3);
 });
 
-test("paypal webhook does not mark approval-pending subscription as canceling", async () => {
+test("paypal webhook ignores approval-pending event for non-PayPal subscriber", async () => {
   let updatedData: Record<string, unknown> | null = null;
   const handler = createPayPalWebhookHandler({
     markEventProcessed: async () => true,
@@ -1086,8 +1125,56 @@ test("paypal webhook does not mark approval-pending subscription as canceling", 
   });
 
   assert.equal(result.status, 200);
-  assert.equal(updatedData?.["subscriptionStatus"], "incomplete");
-  assert.equal(updatedData?.["subscriptionCancelAtPeriodEnd"], false);
+  assert.equal(updatedData, null);
+});
+
+test("paypal webhook does not clobber stripe grace-period state on approval-pending event", async () => {
+  let updatedData: Record<string, unknown> | null = null;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: (status) => status === "active",
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_stripe_grace",
+      subscriptionProvider: "stripe",
+      stripeSubscriptionId: "sub_grace",
+      paypalSubscriptionId: null,
+      subscriptionPriceId: "price_1",
+      pendingSubscriptionPriceId: null,
+      subscriptionCurrentPeriodEnd: new Date("2099-01-01T00:00:00Z"),
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async (_clerkUserId, data) => {
+      updatedData = data as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_stripe_grace_pending",
+      event_type: "BILLING.SUBSCRIPTION.CREATED",
+      resource: {
+        id: "I-SUB-PENDING-GRACE",
+        status: "APPROVAL_PENDING",
+        custom_id: "user_stripe_grace",
+        plan_id: "plan_2",
+      },
+    },
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(updatedData, null);
 });
 
 test("paypal webhook preserves existing period end when next billing time is missing", async () => {
@@ -1186,6 +1273,57 @@ test("paypal webhook ignores stale events when user is on Stripe", async () => {
   });
   assert.equal(result.status, 200);
   assert.equal(updated, 0);
+});
+
+test("paypal webhook accepts activation for stripe user when custom_id matches", async () => {
+  let updatedData: Record<string, unknown> | null = null;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: (status) => status === "active",
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_transition",
+      subscriptionProvider: "stripe",
+      stripeSubscriptionId: "sub_old",
+      paypalSubscriptionId: null,
+      subscriptionPriceId: "price_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async (_clerkUserId, data) => {
+      updatedData = data as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_transition_activated",
+      event_type: "BILLING.SUBSCRIPTION.ACTIVATED",
+      resource: {
+        id: "I-NEW-PP",
+        status: "ACTIVE",
+        custom_id: "user_transition",
+        plan_id: "plan_2",
+      },
+    },
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(updatedData?.["subscriptionProvider"], "paypal");
+  assert.equal(updatedData?.["paypalSubscriptionId"], "I-NEW-PP");
+  assert.equal(updatedData?.["subscriptionStatus"], "active");
+  assert.equal(updatedData?.["supporterTier"], 2);
 });
 
 test("paypal webhook ordering prefers event create_time over transmission time", async () => {

--- a/tests/billing.api.test.ts
+++ b/tests/billing.api.test.ts
@@ -1179,7 +1179,7 @@ test("paypal webhook does not clobber stripe grace-period state on approval-pend
 
 test("paypal webhook preserves existing period end when next billing time is missing", async () => {
   let updatedData: Record<string, unknown> | null = null;
-  const existingPeriodEnd = new Date("2026-05-01T00:00:00Z");
+  const existingPeriodEnd = new Date("2099-05-01T00:00:00Z");
   const handler = createPayPalWebhookHandler({
     markEventProcessed: async () => true,
     unmarkEventProcessed: async () => {},
@@ -1226,6 +1226,7 @@ test("paypal webhook preserves existing period end when next billing time is mis
   assert.equal(updatedData?.["subscriptionStatus"], "canceled");
   assert.equal(updatedData?.["subscriptionCancelAtPeriodEnd"], true);
   assert.deepEqual(updatedData?.["subscriptionCurrentPeriodEnd"], existingPeriodEnd);
+  assert.equal(updatedData?.["supporterTier"], 1);
 });
 
 test("paypal webhook ignores stale events when user is on Stripe", async () => {

--- a/tests/billing.api.test.ts
+++ b/tests/billing.api.test.ts
@@ -2,9 +2,13 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type Stripe from "stripe";
 import {
+  cancelPayPalSubscriptionHandler,
+  changePayPalPlanHandler,
   createCheckoutSessionHandler,
+  createPayPalSubscriptionHandler,
   createPortalSessionHandler,
 } from "../src/server/api/billingRouteHandlers";
+import { createPayPalWebhookHandler } from "../src/server/api/paypalWebhookRouteHandler";
 import { createStripeWebhookHandler } from "../src/server/api/stripeWebhookRouteHandler";
 
 function createHeaders(input?: Record<string, string>) {
@@ -190,6 +194,254 @@ test("create portal session returns URL on success", async () => {
   assert.equal(result.status, 200);
   assert.equal((result.body as any).url, "https://stripe.test/portal");
   assert.equal(returnUrl, `${expectedOrigin}/billing`);
+});
+
+test("create paypal subscription enforces feature flag", async () => {
+  let created = 0;
+  const handler = createPayPalSubscriptionHandler({
+    getAuthUserId: async () => "user_1",
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    isPayPalEnabled: () => false,
+    findUserByClerkId: async () => ({ clerkUserId: "user_1", subscriptionStatus: null }),
+    createPayPalSubscription: async () => {
+      created += 1;
+      return {
+        id: "I-SUB",
+        status: "active",
+        approveUrl: "https://paypal.test",
+        payerId: "payer_1",
+      };
+    },
+    recordPayPalSubscription: async () => {},
+  });
+  const result = await handler({
+    method: "POST",
+    body: { tier: 1 },
+    headers: createHeaders(),
+  });
+  assert.equal(result.status, 404);
+  assert.equal(created, 0);
+});
+
+test("create paypal subscription returns approval URL", async () => {
+  let recorded: Record<string, unknown> | null = null;
+  let receivedOrigin = "";
+  const handler = createPayPalSubscriptionHandler({
+    getAuthUserId: async () => "user_1",
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({ clerkUserId: "user_1", subscriptionStatus: null }),
+    createPayPalSubscription: async (params) => {
+      receivedOrigin = params.origin;
+      return {
+        id: "I-SUB",
+        status: "incomplete",
+        approveUrl: "https://paypal.test/approve",
+        payerId: "payer_1",
+      };
+    },
+    recordPayPalSubscription: async (params) => {
+      recorded = params as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    body: { tier: 2 },
+    headers: createHeaders({ host: "example.com", "x-forwarded-proto": "https" }),
+  });
+  const expectedOrigin =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "https://example.com";
+  assert.equal(result.status, 200);
+  assert.equal((result.body as { url: string }).url, "https://paypal.test/approve");
+  assert.equal(receivedOrigin, expectedOrigin);
+  assert.equal(recorded?.["subscriptionPriceId"], "plan_2");
+});
+
+test("create paypal subscription blocks duplicate active subscriptions", async () => {
+  let created = 0;
+  const handler = createPayPalSubscriptionHandler({
+    getAuthUserId: async () => "user_1",
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({ clerkUserId: "user_1", subscriptionStatus: "active" }),
+    createPayPalSubscription: async () => {
+      created += 1;
+      return {
+        id: "I-SUB",
+        status: "active",
+        approveUrl: "https://paypal.test/approve",
+        payerId: "payer_1",
+      };
+    },
+    recordPayPalSubscription: async () => {},
+  });
+
+  const result = await handler({
+    method: "POST",
+    body: { tier: 2 },
+    headers: createHeaders(),
+  });
+  assert.equal(result.status, 409);
+  assert.equal(created, 0);
+});
+
+test("cancel paypal subscription marks cancel at period end without dropping tier", async () => {
+  let cancelCalls = 0;
+  let capturedUpdateClerkUserId = "";
+  const handler = cancelPayPalSubscriptionHandler({
+    getAuthUserId: async () => "user_1",
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionProvider: "paypal",
+      paypalSubscriptionId: "I-SUB-1",
+    }),
+    cancelPayPalSubscription: async ({ paypalSubscriptionId, reason }) => {
+      cancelCalls += 1;
+      assert.equal(paypalSubscriptionId, "I-SUB-1");
+      assert.equal(reason, "User requested cancellation.");
+    },
+    markPayPalSubscriptionCancelAtPeriodEnd: async ({ clerkUserId }) => {
+      capturedUpdateClerkUserId = clerkUserId;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    body: null,
+    headers: createHeaders({ host: "example.com", "x-forwarded-proto": "https" }),
+  });
+
+  const expectedOrigin =
+    process.env.NEXT_PUBLIC_API_URL?.replace(/\/$/, "") ?? "https://example.com";
+  assert.equal(result.status, 200);
+  assert.equal((result.body as { url: string }).url, `${expectedOrigin}/billing`);
+  assert.equal(cancelCalls, 1);
+  assert.equal(capturedUpdateClerkUserId, "user_1");
+});
+
+test("cancel paypal subscription rejects unsupported states", async () => {
+  let cancelCalls = 0;
+  const handler = cancelPayPalSubscriptionHandler({
+    getAuthUserId: async () => "user_1",
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionProvider: "stripe",
+      paypalSubscriptionId: "I-SUB-1",
+    }),
+    cancelPayPalSubscription: async () => {
+      cancelCalls += 1;
+    },
+    markPayPalSubscriptionCancelAtPeriodEnd: async () => {},
+  });
+
+  const result = await handler({
+    method: "POST",
+    body: null,
+    headers: createHeaders(),
+  });
+
+  assert.equal(result.status, 404);
+  assert.equal(cancelCalls, 0);
+});
+
+test("cancel paypal subscription enforces method, feature flag, and auth", async () => {
+  const handler = cancelPayPalSubscriptionHandler({
+    getAuthUserId: async () => null,
+    isPayPalEnabled: () => false,
+    findUserByClerkId: async () => null,
+    cancelPayPalSubscription: async () => {},
+    markPayPalSubscriptionCancelAtPeriodEnd: async () => {},
+  });
+
+  const methodResult = await handler({
+    method: "GET",
+    body: null,
+    headers: createHeaders(),
+  });
+  assert.equal(methodResult.status, 405);
+
+  const featureResult = await handler({
+    method: "POST",
+    body: null,
+    headers: createHeaders(),
+  });
+  assert.equal(featureResult.status, 404);
+
+  const authHandler = cancelPayPalSubscriptionHandler({
+    getAuthUserId: async () => null,
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => null,
+    cancelPayPalSubscription: async () => {},
+    markPayPalSubscriptionCancelAtPeriodEnd: async () => {},
+  });
+  const authResult = await authHandler({
+    method: "POST",
+    body: null,
+    headers: createHeaders(),
+  });
+  assert.equal(authResult.status, 401);
+});
+
+test("change paypal plan schedules pending tier and returns approval url", async () => {
+  let revisedPlanId = "";
+  let updatedPendingPlanId = "";
+  const handler = changePayPalPlanHandler({
+    getAuthUserId: async () => "user_1",
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionProvider: "paypal",
+      subscriptionStatus: "active",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+      paypalSubscriptionId: "I-SUB",
+    }),
+    revisePayPalSubscriptionPlan: async ({ planId }) => {
+      revisedPlanId = planId;
+      return { approveUrl: "https://paypal.test/reapprove" };
+    },
+    updatePendingSubscriptionPriceId: async ({ pendingSubscriptionPriceId }) => {
+      updatedPendingPlanId = pendingSubscriptionPriceId;
+    },
+  });
+  const result = await handler({
+    method: "POST",
+    body: { tier: 3 },
+    headers: createHeaders({ host: "example.com", "x-forwarded-proto": "https" }),
+  });
+  assert.equal(result.status, 200);
+  assert.equal((result.body as { url: string }).url, "https://paypal.test/reapprove");
+  assert.equal(revisedPlanId, "plan_3");
+  assert.equal(updatedPendingPlanId, "plan_3");
+});
+
+test("change paypal plan rejects duplicate pending tier", async () => {
+  const handler = changePayPalPlanHandler({
+    getAuthUserId: async () => "user_1",
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    isPayPalEnabled: () => true,
+    findUserByClerkId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionProvider: "paypal",
+      subscriptionStatus: "active",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: "plan_3",
+      paypalSubscriptionId: "I-SUB",
+    }),
+    revisePayPalSubscriptionPlan: async () => ({ approveUrl: null }),
+    updatePendingSubscriptionPriceId: async () => {},
+  });
+
+  const result = await handler({
+    method: "POST",
+    body: { tier: 3 },
+    headers: createHeaders(),
+  });
+  assert.equal(result.status, 409);
 });
 
 const subscriptionEvent = (overrides?: Partial<Stripe.Subscription>): Stripe.Event =>
@@ -412,6 +664,9 @@ test("stripe webhook links checkout completion by clerk metadata", async () => {
   assert.equal(result.status, 200);
   assert.equal(updatedData.stripeCustomerId, "cus_2");
   assert.equal(updatedData.stripeSubscriptionId, "sub_2");
+  assert.equal(updatedData.paypalPayerId, null);
+  assert.equal(updatedData.paypalSubscriptionId, null);
+  assert.equal(updatedData.pendingSubscriptionPriceId, null);
 });
 
 test("stripe webhook links checkout completion with tier metadata present", async () => {
@@ -456,6 +711,161 @@ test("stripe webhook links checkout completion with tier metadata present", asyn
   assert.equal(result.status, 200);
   assert.equal(updatedData.stripeCustomerId, "cus_3");
   assert.equal(updatedData.stripeSubscriptionId, "sub_3");
+  assert.equal(updatedData.paypalPayerId, null);
+  assert.equal(updatedData.paypalSubscriptionId, null);
+  assert.equal(updatedData.pendingSubscriptionPriceId, null);
+});
+
+test("stripe webhook ignores stale subscription events when user is on PayPal", async () => {
+  let updateCalls = 0;
+  const handler = createStripeWebhookHandler({
+    getWebhookSecret: () => "whsec_test",
+    constructEvent: () =>
+      subscriptionEvent({
+        id: "sub_stale",
+        status: "canceled",
+      }),
+    getPriceMap: () => ({ 1: "price_1", 2: "price_2", 3: "price_3" }),
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_pp",
+      subscriptionProvider: "paypal",
+      stripeSubscriptionId: null,
+      paypalSubscriptionId: "I-ACTIVE",
+    }),
+    findUserByStripeCustomerId: async () => null,
+    updateUserSubscription: async () => {
+      updateCalls += 1;
+    },
+    extractRecurringPriceId: () => "price_3",
+    getTierFromPriceId: () => 3,
+    shouldGrantSupporterBadge: () => false,
+  });
+
+  const result = await handler({
+    method: "POST",
+    signature: "sig",
+    rawBody: Buffer.from("{}"),
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updateCalls, 0);
+});
+
+test("stripe webhook ignores subscription events when provider is PayPal and Stripe id is untracked", async () => {
+  let updateCalls = 0;
+  const handler = createStripeWebhookHandler({
+    getWebhookSecret: () => "whsec_test",
+    constructEvent: () =>
+      subscriptionEvent({
+        id: "sub_orphaned",
+        status: "active",
+        metadata: { clerkUserId: "user_pp_only" },
+      }),
+    getPriceMap: () => ({ 1: "price_1", 2: "price_2", 3: "price_3" }),
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_pp_only",
+      subscriptionProvider: "paypal",
+      stripeSubscriptionId: null,
+      paypalSubscriptionId: null,
+    }),
+    findUserByStripeCustomerId: async () => null,
+    updateUserSubscription: async () => {
+      updateCalls += 1;
+    },
+    extractRecurringPriceId: () => "price_3",
+    getTierFromPriceId: () => 3,
+    shouldGrantSupporterBadge: () => true,
+  });
+
+  const result = await handler({
+    method: "POST",
+    signature: "sig",
+    rawBody: Buffer.from("{}"),
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updateCalls, 0);
+});
+
+test("stripe webhook ignores out-of-order events by provider timestamp", async () => {
+  let updateCalls = 0;
+  const handler = createStripeWebhookHandler({
+    getWebhookSecret: () => "whsec_test",
+    constructEvent: () =>
+      ({
+        ...subscriptionEvent({
+          id: "sub_older",
+          status: "active",
+          metadata: { clerkUserId: "user_ordered" },
+        }),
+        created: 1_700_000_000,
+      }) as Stripe.Event,
+    getPriceMap: () => ({ 1: "price_1", 2: "price_2", 3: "price_3" }),
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_ordered",
+      subscriptionProvider: "stripe",
+      subscriptionProviderUpdatedAt: new Date("2026-04-20T20:00:00Z"),
+      stripeSubscriptionId: "sub_older",
+      paypalSubscriptionId: null,
+    }),
+    findUserByStripeCustomerId: async () => null,
+    updateUserSubscription: async () => {
+      updateCalls += 1;
+    },
+    extractRecurringPriceId: () => "price_3",
+    getTierFromPriceId: () => 3,
+    shouldGrantSupporterBadge: () => true,
+  });
+
+  const result = await handler({
+    method: "POST",
+    signature: "sig",
+    rawBody: Buffer.from("{}"),
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updateCalls, 0);
+});
+
+test("stripe webhook applies subscription sync when tracked Stripe subscription matches", async () => {
+  let updated: any = null;
+  const handler = createStripeWebhookHandler({
+    getWebhookSecret: () => "whsec_test",
+    constructEvent: () =>
+      subscriptionEvent({
+        id: "sub_tracked",
+        status: "active",
+        metadata: { clerkUserId: "user_mixed" },
+      }),
+    getPriceMap: () => ({ 1: "price_1", 2: "price_2", 3: "price_3" }),
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_mixed",
+      subscriptionProvider: "stripe",
+      stripeSubscriptionId: "sub_tracked",
+      paypalSubscriptionId: "I-OLD",
+    }),
+    findUserByStripeCustomerId: async () => null,
+    updateUserSubscription: async (_id, data) => {
+      updated = data;
+    },
+    extractRecurringPriceId: () => "price_3",
+    getTierFromPriceId: () => 3,
+    shouldGrantSupporterBadge: () => true,
+  });
+
+  const result = await handler({
+    method: "POST",
+    signature: "sig",
+    rawBody: Buffer.from("{}"),
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updated.paypalSubscriptionId, null);
+  assert.equal(updated.supporterTier, 3);
 });
 
 test("stripe webhook unmarks event when processing fails", async () => {
@@ -485,4 +895,344 @@ test("stripe webhook unmarks event when processing fails", async () => {
   });
   assert.equal(result.status, 500);
   assert.deepEqual(unmarked, ["evt_sub"]);
+});
+
+test("paypal webhook validates method and headers", async () => {
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: () => true,
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalPayerId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    updateUserSubscription: async () => {},
+  });
+
+  const wrongMethod = await handler({
+    method: "GET",
+    headers: createHeaders(),
+    body: {},
+  });
+  assert.equal(wrongMethod.status, 405);
+
+  const missingHeaders = await handler({
+    method: "POST",
+    headers: createHeaders(),
+    body: {},
+  });
+  assert.equal(missingHeaders.status, 400);
+});
+
+test("paypal webhook short-circuits duplicates", async () => {
+  let updated = 0;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => false,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: () => true,
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalPayerId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    updateUserSubscription: async () => {
+      updated += 1;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_1",
+      event_type: "BILLING.SUBSCRIPTION.ACTIVATED",
+      resource: {
+        id: "I-SUB",
+        status: "ACTIVE",
+        custom_id: "user_1",
+        plan_id: "plan_2",
+      },
+    },
+  });
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, { received: true, duplicate: true });
+  assert.equal(updated, 0);
+});
+
+test("paypal webhook updates subscription state", async () => {
+  let updatedData: Record<string, unknown> | null = null;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: (status) => status === "active",
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async (_clerkUserId, data) => {
+      updatedData = data as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_1",
+      event_type: "BILLING.SUBSCRIPTION.ACTIVATED",
+      resource: {
+        id: "I-SUB",
+        status: "ACTIVE",
+        custom_id: "user_1",
+        plan_id: "plan_3",
+        subscriber: {
+          payer_id: "payer_123",
+        },
+        billing_info: {
+          next_billing_time: "2026-05-01T00:00:00Z",
+        },
+      },
+    },
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updatedData?.["subscriptionProvider"], "paypal");
+  assert.equal(updatedData?.["subscriptionStatus"], "active");
+  assert.equal(updatedData?.["subscriptionPriceId"], "plan_3");
+  assert.equal(updatedData?.["subscriptionCancelAtPeriodEnd"], false);
+  assert.equal(updatedData?.["supporterTier"], 3);
+});
+
+test("paypal webhook does not mark approval-pending subscription as canceling", async () => {
+  let updatedData: Record<string, unknown> | null = null;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: (status) => status === "active",
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async (_clerkUserId, data) => {
+      updatedData = data as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_approval_pending",
+      event_type: "BILLING.SUBSCRIPTION.CREATED",
+      resource: {
+        id: "I-SUB-PENDING",
+        status: "APPROVAL_PENDING",
+        custom_id: "user_1",
+        plan_id: "plan_1",
+      },
+    },
+  });
+
+  assert.equal(result.status, 200);
+  assert.equal(updatedData?.["subscriptionStatus"], "incomplete");
+  assert.equal(updatedData?.["subscriptionCancelAtPeriodEnd"], false);
+});
+
+test("paypal webhook preserves existing period end when next billing time is missing", async () => {
+  let updatedData: Record<string, unknown> | null = null;
+  const existingPeriodEnd = new Date("2026-05-01T00:00:00Z");
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: (status) => status === "active",
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+      subscriptionCurrentPeriodEnd: existingPeriodEnd,
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async (_clerkUserId, data) => {
+      updatedData = data as unknown as Record<string, unknown>;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_2",
+      event_type: "BILLING.SUBSCRIPTION.CANCELLED",
+      resource: {
+        id: "I-SUB",
+        status: "CANCELLED",
+        custom_id: "user_1",
+        plan_id: "plan_1",
+        subscriber: {
+          payer_id: "payer_123",
+        },
+      },
+    },
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updatedData?.["subscriptionStatus"], "canceled");
+  assert.equal(updatedData?.["subscriptionCancelAtPeriodEnd"], true);
+  assert.deepEqual(updatedData?.["subscriptionCurrentPeriodEnd"], existingPeriodEnd);
+});
+
+test("paypal webhook ignores stale events when user is on Stripe", async () => {
+  let updated = 0;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: () => true,
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionProvider: "stripe",
+      stripeSubscriptionId: "sub_live",
+      paypalSubscriptionId: null,
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async () => {
+      updated += 1;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "time",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_3",
+      event_type: "BILLING.SUBSCRIPTION.UPDATED",
+      resource: {
+        id: "I-OLD",
+        status: "ACTIVE",
+        custom_id: "user_1",
+        plan_id: "plan_2",
+      },
+    },
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updated, 0);
+});
+
+test("paypal webhook ordering prefers event create_time over transmission time", async () => {
+  let updated = 0;
+  const handler = createPayPalWebhookHandler({
+    markEventProcessed: async () => true,
+    unmarkEventProcessed: async () => {},
+    verifyWebhook: async () => true,
+    getPlanMap: () => ({ 1: "plan_1", 2: "plan_2", 3: "plan_3" }),
+    shouldGrantSupporterBadge: () => true,
+    findUserByClerkUserId: async () => ({
+      clerkUserId: "user_1",
+      subscriptionProvider: "paypal",
+      subscriptionProviderUpdatedAt: new Date("2026-04-20T20:00:00Z"),
+      stripeSubscriptionId: null,
+      paypalSubscriptionId: "I-SUB-LIVE",
+      subscriptionPriceId: "plan_1",
+      pendingSubscriptionPriceId: null,
+    }),
+    findUserByPayPalSubscriptionId: async () => null,
+    findUserByPayPalPayerId: async () => null,
+    updateUserSubscription: async () => {
+      updated += 1;
+    },
+  });
+
+  const result = await handler({
+    method: "POST",
+    headers: createHeaders({
+      "paypal-transmission-id": "id",
+      "paypal-transmission-time": "2026-04-20T22:00:00Z",
+      "paypal-transmission-sig": "sig",
+      "paypal-cert-url": "https://example.com/cert",
+      "paypal-auth-algo": "algo",
+    }),
+    body: {
+      id: "evt_4",
+      create_time: "2026-04-20T19:00:00Z",
+      event_type: "BILLING.SUBSCRIPTION.UPDATED",
+      resource: {
+        id: "I-SUB-LIVE",
+        status: "ACTIVE",
+        custom_id: "user_1",
+        plan_id: "plan_2",
+      },
+    },
+  });
+  assert.equal(result.status, 200);
+  assert.equal(updated, 0);
 });


### PR DESCRIPTION
### Changes
This change lets supporters subscribe via PayPal in addition to Stripe, with deferred PayPal tier switches and cancel-at-period-end behavior that keeps access through the current period. User records now track billing provider, pending plan changes, and a provider update timestamp so Stripe and PayPal webhooks do not clobber each other when events arrive out of order. The Contribute page, Billing page, and support prompt share a clearer payment-method choice; legacy subscriptionProvider nulls are backfilled and self-healed where needed. Includes Prisma migrations, reconcile route updates, and expanded API tests for billing flows.