### PR TITLE
Split draft ban schedule (before vs after picks) with undo and test fixes

### DIFF
--- a/convex/drafts.ts
+++ b/convex/drafts.ts
@@ -86,6 +86,84 @@ function generateBanSequence(
   return sequence;
 }
 
+type BanTimingMode = "before_picks" | "after_2_picks" | "after_3_picks" | "after_4_picks";
+
+const DEFAULT_BAN_TIMING_MODE: BanTimingMode = "before_picks";
+const BAN_TIMING_SPLIT_PICK_COUNT: Record<
+  Exclude<BanTimingMode, "before_picks">,
+  number
+> = {
+  after_2_picks: 2,
+  after_3_picks: 3,
+  after_4_picks: 4,
+};
+
+function getBanTimingMode(draft: { banTimingMode?: BanTimingMode }): BanTimingMode {
+  return draft.banTimingMode ?? DEFAULT_BAN_TIMING_MODE;
+}
+
+function getTotalPickCount(teamSize: number): number {
+  return Math.max(0, (teamSize - 1) * 2);
+}
+
+function getDeferredBanTriggerPickCount(
+  mode: BanTimingMode,
+  totalPickCount: number
+): number | undefined {
+  if (mode === "before_picks") return undefined;
+  const requested = BAN_TIMING_SPLIT_PICK_COUNT[mode];
+  if (totalPickCount <= 0) return undefined;
+  return Math.min(requested, Math.max(1, totalPickCount - 1));
+}
+
+function buildBanPlan(
+  firstPickTeam: 1 | 2,
+  bansPerCaptain: number,
+  mode: BanTimingMode,
+  teamSize: number
+): {
+  initialBanSequence: (1 | 2)[];
+  deferredBanSequence: (1 | 2)[];
+  deferredBanTriggerPickCount?: number;
+} {
+  if (bansPerCaptain <= 0) {
+    return {
+      initialBanSequence: [],
+      deferredBanSequence: [],
+      deferredBanTriggerPickCount: undefined,
+    };
+  }
+  if (mode === "before_picks") {
+    return {
+      initialBanSequence: generateBanSequence(firstPickTeam, bansPerCaptain),
+      deferredBanSequence: [],
+      deferredBanTriggerPickCount: undefined,
+    };
+  }
+  const deferredBansPerCaptain = Math.max(0, bansPerCaptain - 1);
+  return {
+    initialBanSequence: generateBanSequence(firstPickTeam, 1),
+    deferredBanSequence:
+      deferredBansPerCaptain > 0
+        ? generateBanSequence(firstPickTeam, deferredBansPerCaptain)
+        : [],
+    deferredBanTriggerPickCount: getDeferredBanTriggerPickCount(
+      mode,
+      getTotalPickCount(teamSize)
+    ),
+  };
+}
+
+function canTriggerDeferredBanPhase(draft: {
+  deferredBanTriggered?: boolean;
+  deferredBanSequence?: (1 | 2)[];
+  deferredBanTriggerPickCount?: number;
+}): boolean {
+  if (draft.deferredBanTriggered) return false;
+  if (!draft.deferredBanSequence || draft.deferredBanSequence.length === 0) return false;
+  return typeof draft.deferredBanTriggerPickCount === "number";
+}
+
 function buildSetScore(team1Wins: number, team2Wins: number): string {
   return `${team1Wins}-${team2Wins}`;
 }
@@ -344,6 +422,7 @@ export const createDraft = mutation({
       teamSize: defaultTeamSize,
       pickOrderMode: "alternating",
       bansPerCaptain: getDefaultBansPerCaptain("traditional"),
+      banTimingMode: DEFAULT_BAN_TIMING_MODE,
       discordGuildId: args.discordGuildId,
       discordGuildName: args.discordGuildName,
       discordChannelId: args.discordChannelId,
@@ -451,6 +530,14 @@ export const updateSettings = mutation({
       v.union(v.literal("snake"), v.literal("alternating"))
     ),
     bansPerCaptain: v.optional(v.number()),
+    banTimingMode: v.optional(
+      v.union(
+        v.literal("before_picks"),
+        v.literal("after_2_picks"),
+        v.literal("after_3_picks"),
+        v.literal("after_4_picks")
+      )
+    ),
     token: v.string(),
   },
   handler: async (ctx, args) => {
@@ -505,6 +592,7 @@ export const updateSettings = mutation({
         (args.type !== draft.type
           ? getDefaultBansPerCaptain(args.type)
           : getBansPerCaptain(draft)),
+      banTimingMode: args.banTimingMode ?? getBanTimingMode(draft),
       safeClassNames,
     });
   },
@@ -550,6 +638,15 @@ export const startDraft = mutation({
         coinFlipChoice: undefined,
         firstPickTeam: undefined,
         firstRealmPickTeam: undefined,
+        banSequence: undefined,
+      initialBanSequence: undefined,
+        currentBanIndex: undefined,
+        activeBanPhase: undefined,
+        pickSequence: undefined,
+        currentPickIndex: undefined,
+        deferredBanSequence: undefined,
+        deferredBanTriggerPickCount: undefined,
+        deferredBanTriggered: false,
       });
       return;
     }
@@ -631,9 +728,13 @@ export const setCoinFlipChoice = mutation({
       nextStatus = "banning";
     }
 
-    const bansPerCaptain = getBansPerCaptain(draft);
-    const banSequence = generateBanSequence(firstPickTeam, bansPerCaptain);
-    const shouldSkipBans = draft.type === "pvp" && banSequence.length === 0;
+    const banPlan = buildBanPlan(
+      firstPickTeam,
+      getBansPerCaptain(draft),
+      getBanTimingMode(draft),
+      draft.teamSize
+    );
+    const shouldSkipBans = draft.type === "pvp" && banPlan.initialBanSequence.length === 0;
     const pickSequence = shouldSkipBans
       ? generatePickSequence(
           draft.teamSize,
@@ -650,8 +751,16 @@ export const setCoinFlipChoice = mutation({
       coinFlipChoice: args.choice,
       firstPickTeam,
       firstRealmPickTeam,
-      banSequence: banSequence.length > 0 ? banSequence : undefined,
-      currentBanIndex: banSequence.length > 0 ? 0 : undefined,
+      banSequence:
+        banPlan.initialBanSequence.length > 0 ? banPlan.initialBanSequence : undefined,
+      initialBanSequence:
+        banPlan.initialBanSequence.length > 0 ? banPlan.initialBanSequence : undefined,
+      currentBanIndex: banPlan.initialBanSequence.length > 0 ? 0 : undefined,
+      activeBanPhase: banPlan.initialBanSequence.length > 0 ? "initial" : undefined,
+      deferredBanSequence:
+        banPlan.deferredBanSequence.length > 0 ? banPlan.deferredBanSequence : undefined,
+      deferredBanTriggerPickCount: banPlan.deferredBanTriggerPickCount,
+      deferredBanTriggered: false,
       pickSequence,
       currentPickIndex: shouldSkipBans ? 0 : undefined,
     });
@@ -734,9 +843,16 @@ export const pickRealm = mutation({
           pickSequence,
           currentPickIndex: 0,
           currentBanIndex: undefined,
+          activeBanPhase: undefined,
         });
       } else {
-        await ctx.db.patch(args.draftId, { ...updates, status: "banning" });
+        await ctx.db.patch(args.draftId, {
+          ...updates,
+          banSequence: draft.initialBanSequence ?? draft.banSequence,
+          status: "banning",
+          currentBanIndex: 0,
+          activeBanPhase: "initial",
+        });
       }
     } else {
       await ctx.db.patch(args.draftId, updates);
@@ -959,11 +1075,23 @@ export const banClass = mutation({
       team: currentBanTeam,
       className: normalizedClassName,
       source: "captain",
+      phase: draft.activeBanPhase ?? "initial",
     });
 
     const nextBanIndex = draft.currentBanIndex! + 1;
 
     if (nextBanIndex >= draft.banSequence!.length) {
+      if (draft.activeBanPhase === "deferred") {
+        const nextPickIndex = draft.currentPickIndex ?? 0;
+        const totalPicks = draft.pickSequence?.length ?? 0;
+        await ctx.db.patch(args.draftId, {
+          status: nextPickIndex >= totalPicks ? "complete" : "drafting",
+          banSequence: draft.initialBanSequence ?? draft.banSequence,
+          currentBanIndex: nextBanIndex,
+          activeBanPhase: undefined,
+        });
+        return;
+      }
       const pickSequence = generatePickSequence(
         draft.teamSize,
         draft.firstPickTeam!,
@@ -974,6 +1102,7 @@ export const banClass = mutation({
         currentBanIndex: nextBanIndex,
         pickSequence,
         currentPickIndex: 0,
+        activeBanPhase: undefined,
       });
     } else {
       await ctx.db.patch(args.draftId, {
@@ -1024,6 +1153,20 @@ export const pickPlayer = mutation({
     });
 
     const nextPickIndex = draft.currentPickIndex! + 1;
+    if (
+      canTriggerDeferredBanPhase(draft) &&
+      nextPickIndex >= (draft.deferredBanTriggerPickCount ?? Number.MAX_SAFE_INTEGER)
+    ) {
+      await ctx.db.patch(args.draftId, {
+        status: "banning",
+        currentPickIndex: nextPickIndex,
+        banSequence: draft.deferredBanSequence,
+        currentBanIndex: 0,
+        activeBanPhase: "deferred",
+        deferredBanTriggered: true,
+      });
+      return;
+    }
 
     if (nextPickIndex >= draft.pickSequence!.length) {
       await ctx.db.patch(args.draftId, {
@@ -1446,19 +1589,36 @@ export const undoLastAction = mutation({
     }
 
     if (draft.status === "drafting") {
-      if (draft.currentPickIndex === 0) {
+      const atInitialBanBoundary = draft.currentPickIndex === 0;
+      const atDeferredBanBoundary =
+        draft.deferredBanTriggered &&
+        typeof draft.deferredBanTriggerPickCount === "number" &&
+        draft.currentPickIndex === draft.deferredBanTriggerPickCount;
+      if (atInitialBanBoundary || atDeferredBanBoundary) {
         const bans = await ctx.db
           .query("draftBans")
           .withIndex("by_draft", (q) => q.eq("draftId", args.draftId))
           .collect();
-        if (bans.length > 0) {
-          const lastBan = bans[bans.length - 1];
+        const boundaryPhase: "initial" | "deferred" = atInitialBanBoundary
+          ? "initial"
+          : "deferred";
+        const boundaryBanSequence =
+          boundaryPhase === "initial"
+            ? draft.initialBanSequence ?? draft.banSequence
+            : draft.deferredBanSequence ?? draft.banSequence;
+        const phaseCaptainBans = bans.filter(
+          (ban) => ban.source === "captain" && (ban.phase ?? "initial") === boundaryPhase
+        );
+        if (phaseCaptainBans.length > 0) {
+          const lastBan = phaseCaptainBans[phaseCaptainBans.length - 1];
           await ctx.db.delete(lastBan._id);
           await ctx.db.patch(args.draftId, {
             status: "banning",
-            currentBanIndex: draft.banSequence!.length - 1,
-            pickSequence: undefined,
-            currentPickIndex: undefined,
+            banSequence: boundaryBanSequence,
+            currentBanIndex: (boundaryBanSequence?.length ?? 1) - 1,
+            pickSequence: atInitialBanBoundary ? undefined : draft.pickSequence,
+            currentPickIndex: atInitialBanBoundary ? undefined : draft.currentPickIndex,
+            activeBanPhase: boundaryPhase,
           });
         }
         return;
@@ -1489,7 +1649,32 @@ export const undoLastAction = mutation({
         .query("draftBans")
         .withIndex("by_draft", (q) => q.eq("draftId", args.draftId))
         .collect();
-      if (bans.length === 0) {
+      if ((draft.currentBanIndex ?? 0) === 0) {
+        if (draft.activeBanPhase === "deferred") {
+          const players = await ctx.db
+            .query("draftPlayers")
+            .withIndex("by_draft", (q) => q.eq("draftId", args.draftId))
+            .collect();
+          const triggeringPickIndex = draft.currentPickIndex ?? 0;
+          const triggeringPickedPlayer = players.find(
+            (p) => p.pickOrder === triggeringPickIndex
+          );
+          if (triggeringPickedPlayer) {
+            await ctx.db.patch(triggeringPickedPlayer._id, {
+              team: undefined,
+              pickOrder: undefined,
+            });
+          }
+          await ctx.db.patch(args.draftId, {
+            status: "drafting",
+            banSequence: draft.initialBanSequence ?? draft.banSequence,
+            currentPickIndex: Math.max(0, triggeringPickIndex - 1),
+            currentBanIndex: undefined,
+            activeBanPhase: undefined,
+            deferredBanTriggered: false,
+          });
+          return;
+        }
         if (draft.type === "traditional") {
           const secondRealmTeam = draft.firstRealmPickTeam === 1 ? 2 : 1;
           const realmToClear = secondRealmTeam === 1 ? "team1Realm" : "team2Realm";
@@ -1497,6 +1682,7 @@ export const undoLastAction = mutation({
             status: "realm_pick",
             [realmToClear]: undefined,
             currentBanIndex: undefined,
+            activeBanPhase: undefined,
           });
         } else {
           await ctx.db.patch(args.draftId, {
@@ -1504,12 +1690,26 @@ export const undoLastAction = mutation({
             coinFlipChoice: undefined,
             firstPickTeam: undefined,
             banSequence: undefined,
+            initialBanSequence: undefined,
             currentBanIndex: undefined,
+            activeBanPhase: undefined,
+            pickSequence: undefined,
+            currentPickIndex: undefined,
+            deferredBanSequence: undefined,
+            deferredBanTriggerPickCount: undefined,
+            deferredBanTriggered: false,
           });
         }
         return;
       }
-      const lastBan = bans[bans.length - 1];
+      const activePhase = draft.activeBanPhase ?? "initial";
+      const phaseCaptainBans = bans.filter(
+        (ban) => ban.source === "captain" && (ban.phase ?? "initial") === activePhase
+      );
+      const lastBan = phaseCaptainBans[phaseCaptainBans.length - 1];
+      if (!lastBan) {
+        throw new Error("No captain ban found for current phase");
+      }
       await ctx.db.delete(lastBan._id);
       await ctx.db.patch(args.draftId, {
         currentBanIndex: draft.currentBanIndex! - 1,
@@ -1526,7 +1726,14 @@ export const undoLastAction = mutation({
           firstPickTeam: undefined,
           firstRealmPickTeam: undefined,
           banSequence: undefined,
+          initialBanSequence: undefined,
           currentBanIndex: undefined,
+          activeBanPhase: undefined,
+          pickSequence: undefined,
+          currentPickIndex: undefined,
+          deferredBanSequence: undefined,
+          deferredBanTriggerPickCount: undefined,
+          deferredBanTriggered: false,
         });
       } else {
         const realmToClear =

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -38,11 +38,24 @@ export default defineSchema({
       v.union(v.literal("snake"), v.literal("alternating"))
     ),
     bansPerCaptain: v.optional(v.number()),
+    banTimingMode: v.optional(
+      v.union(
+        v.literal("before_picks"),
+        v.literal("after_2_picks"),
+        v.literal("after_3_picks"),
+        v.literal("after_4_picks")
+      )
+    ),
     safeClassNames: v.optional(v.array(v.string())),
     pickSequence: v.optional(v.array(teamNumber)),
     currentPickIndex: v.optional(v.number()),
     banSequence: v.optional(v.array(teamNumber)),
+    initialBanSequence: v.optional(v.array(teamNumber)),
     currentBanIndex: v.optional(v.number()),
+    activeBanPhase: v.optional(v.union(v.literal("initial"), v.literal("deferred"))),
+    deferredBanSequence: v.optional(v.array(teamNumber)),
+    deferredBanTriggerPickCount: v.optional(v.number()),
+    deferredBanTriggered: v.optional(v.boolean()),
     discordGuildId: v.string(),
     discordGuildName: v.optional(v.string()),
     discordChannelId: v.string(),
@@ -110,6 +123,7 @@ export default defineSchema({
     team: teamNumber,
     className: v.string(),
     source: v.optional(v.union(v.literal("captain"), v.literal("auto"))),
+    phase: v.optional(v.union(v.literal("initial"), v.literal("deferred"))),
   }).index("by_draft", ["draftId"]),
 
   draftFights: defineTable({

--- a/src/app/draft/[id]/_components/DraftBoard.tsx
+++ b/src/app/draft/[id]/_components/DraftBoard.tsx
@@ -55,6 +55,7 @@ interface DraftBoardProps {
 }
 
 type PickOrderMode = "snake" | "alternating";
+type BanTimingMode = "before_picks" | "after_2_picks" | "after_3_picks" | "after_4_picks";
 type HighestRankByClassEntry = {
   rank: number;
   formattedRank: string;
@@ -143,6 +144,20 @@ export default function DraftBoard({
     [draft.bans]
   );
   const creatorAutoBans = setupPhase ? draft.bans : sourceTaggedAutoBans;
+  const initialCaptainBans = useMemo(
+    () =>
+      draft.bans.filter(
+        (ban) => ban.source === "captain" && (ban.phase ?? "initial") === "initial"
+      ),
+    [draft.bans]
+  );
+  const deferredCaptainBans = useMemo(
+    () =>
+      draft.bans.filter(
+        (ban) => ban.source === "captain" && (ban.phase ?? "initial") === "deferred"
+      ),
+    [draft.bans]
+  );
   const bannedClassNames = draft.bans.map((b) => b.className);
   const safeClassNames = draft.safeClassNames ?? [];
 
@@ -245,7 +260,8 @@ export default function DraftBoard({
       type: "traditional" | "pvp",
       teamSize: number,
       pickOrderMode: PickOrderMode,
-      bansPerCaptain: number
+      bansPerCaptain: number,
+      banTimingMode: BanTimingMode
     ) => {
       if (busy) return;
       setBusy(true);
@@ -256,6 +272,7 @@ export default function DraftBoard({
           teamSize,
           pickOrderMode,
           bansPerCaptain,
+          banTimingMode,
           token: token!,
         });
       } catch (e) {
@@ -286,7 +303,8 @@ export default function DraftBoard({
       draft.type,
       targetTeamSize,
       draft.pickOrderMode ?? "alternating",
-      draft.bansPerCaptain ?? 2
+      draft.bansPerCaptain ?? 2,
+      draft.banTimingMode ?? "before_picks"
     );
   }, [
     applySettings,
@@ -298,6 +316,7 @@ export default function DraftBoard({
     draft.type,
     draft.pickOrderMode,
     draft.bansPerCaptain,
+    draft.banTimingMode,
     isCreator,
     isSetup,
     token,
@@ -351,9 +370,17 @@ export default function DraftBoard({
     isCreator &&
     token &&
     ((isBanning && (draft.currentBanIndex ?? 0) > 0) ||
-      (isBanning && (draft.currentBanIndex ?? 0) === 0 && draft.bans.length > 0) ||
+      (isBanning &&
+        (draft.currentBanIndex ?? 0) === 0 &&
+        ((draft.activeBanPhase ?? "initial") === "deferred"
+          ? true
+          : initialCaptainBans.length > 0)) ||
       (isDrafting && (draft.currentPickIndex ?? 0) > 0) ||
-      (isDrafting && (draft.currentPickIndex ?? 0) === 0 && draft.bans.length > 0) ||
+      (isDrafting && (draft.currentPickIndex ?? 0) === 0 && initialCaptainBans.length > 0) ||
+      (isDrafting &&
+        draft.deferredBanTriggered &&
+        draft.currentPickIndex === draft.deferredBanTriggerPickCount &&
+        deferredCaptainBans.length > 0) ||
       (isComplete && !draft.gameStarted));
   const cancelPhrase = "cancel this draft";
   const canCancelDraft =
@@ -479,14 +506,16 @@ export default function DraftBoard({
                 type,
                 adjustedTeamSize,
                 draft.pickOrderMode ?? "alternating",
-                draft.bansPerCaptain ?? 2
+                draft.bansPerCaptain ?? 2,
+                draft.banTimingMode ?? "before_picks"
               );
             }
             return applySettings(
               type,
               draft.teamSize,
               draft.pickOrderMode ?? "alternating",
-              draft.bansPerCaptain ?? 2
+              draft.bansPerCaptain ?? 2,
+              draft.banTimingMode ?? "before_picks"
             );
           }}
           onUpdateSize={(teamSize) => {
@@ -495,7 +524,8 @@ export default function DraftBoard({
               draft.type,
               teamSize,
               draft.pickOrderMode ?? "alternating",
-              draft.bansPerCaptain ?? 2
+              draft.bansPerCaptain ?? 2,
+              draft.banTimingMode ?? "before_picks"
             );
           }}
           onUpdatePickOrderMode={(pickOrderMode) => {
@@ -504,7 +534,8 @@ export default function DraftBoard({
               draft.type,
               draft.teamSize,
               pickOrderMode,
-              draft.bansPerCaptain ?? 2
+              draft.bansPerCaptain ?? 2,
+              draft.banTimingMode ?? "before_picks"
             );
           }}
           onUpdateBansPerCaptain={(bansPerCaptain) => {
@@ -513,7 +544,18 @@ export default function DraftBoard({
               draft.type,
               draft.teamSize,
               draft.pickOrderMode ?? "alternating",
-              bansPerCaptain
+              bansPerCaptain,
+              bansPerCaptain <= 1 ? "before_picks" : (draft.banTimingMode ?? "before_picks")
+            );
+          }}
+          onUpdateBanTimingMode={(banTimingMode) => {
+            setSettingsFeedback(null);
+            return applySettings(
+              draft.type,
+              draft.teamSize,
+              draft.pickOrderMode ?? "alternating",
+              draft.bansPerCaptain ?? 2,
+              banTimingMode
             );
           }}
           onStart={() =>
@@ -1050,6 +1092,7 @@ function SettingsBar({
   onUpdateSize,
   onUpdatePickOrderMode,
   onUpdateBansPerCaptain,
+  onUpdateBanTimingMode,
   onStart,
   canStart,
 }: {
@@ -1061,10 +1104,45 @@ function SettingsBar({
   onUpdateSize: (size: number) => void;
   onUpdatePickOrderMode: (mode: PickOrderMode) => void;
   onUpdateBansPerCaptain: (value: number) => void;
+  onUpdateBanTimingMode: (mode: BanTimingMode) => void;
   onStart: () => void;
   canStart: boolean;
 }) {
   const needsCaptains = !hasCaptain1 || !hasCaptain2;
+  const bansPerCaptain = draft.bansPerCaptain ?? 2;
+  const banTimingMode = draft.banTimingMode ?? "before_picks";
+  const timingPickCount =
+    banTimingMode === "after_2_picks"
+      ? 2
+      : banTimingMode === "after_3_picks"
+        ? 3
+        : banTimingMode === "after_4_picks"
+          ? 4
+          : undefined;
+  const formatBanCount = (count: number) =>
+    `${count} ${count === 1 ? "ban" : "bans"}`;
+  const getBanScheduleLabel = (pickCount?: number) => {
+    if (!pickCount) return `All ${formatBanCount(bansPerCaptain)} before picks`;
+    if (bansPerCaptain <= 1) return `1 ban before picks`;
+    return `1 before picks, ${bansPerCaptain - 1} after ${pickCount} picks`;
+  };
+  const banTimingLabel = getBanScheduleLabel(timingPickCount);
+  const prePickBansPerCaptain =
+    banTimingMode === "before_picks" ? bansPerCaptain : Math.min(1, bansPerCaptain);
+  const postPickBansPerCaptain =
+    banTimingMode === "before_picks" ? 0 : Math.max(0, bansPerCaptain - 1);
+  const banTimingSummary =
+    bansPerCaptain === 0
+      ? "No captain bans in this draft."
+      : banTimingMode === "before_picks"
+        ? `Each captain bans ${bansPerCaptain} before player picks start.`
+        : postPickBansPerCaptain === 0
+          ? `Each captain bans ${prePickBansPerCaptain} before picks. There is no second ban round with this ban count.`
+          : `Each captain bans ${prePickBansPerCaptain} before picks, then ${postPickBansPerCaptain} more after ${timingPickCount} total player picks.`;
+  const laterBanDisabled = bansPerCaptain <= 1;
+  const laterBanHelpText = laterBanDisabled
+    ? "Choose 2+ bans per captain to add a later ban round."
+    : `${formatBanCount(1)} before picks, ${formatBanCount(bansPerCaptain - 1)} later.`;
   let buttonLabel = "Start Draft";
   if (!hasCaptain1) {
     buttonLabel = "Assign Captains";
@@ -1142,7 +1220,7 @@ function SettingsBar({
           </Select>
         </div>
         <Select
-          value={String(draft.bansPerCaptain ?? 2)}
+          value={String(bansPerCaptain)}
           onValueChange={(v) => onUpdateBansPerCaptain(Number(v))}
           disabled={busy}
         >
@@ -1157,7 +1235,51 @@ function SettingsBar({
             ))}
           </SelectContent>
         </Select>
+        <Select
+          value={banTimingMode}
+          onValueChange={(v) => onUpdateBanTimingMode(v as BanTimingMode)}
+          disabled={busy}
+        >
+          <SelectTrigger className="h-8 w-full min-w-0 text-xs border-gray-700 bg-gray-800/60 whitespace-nowrap sm:min-w-[250px] xl:w-[250px]">
+            <span className="truncate">{banTimingLabel}</span>
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="before_picks">
+              <div className="flex flex-col">
+                <span>{getBanScheduleLabel()}</span>
+                <span className="text-[10px] text-gray-500">
+                  Finish the full ban round before any player picks.
+                </span>
+              </div>
+            </SelectItem>
+            <SelectItem value="after_2_picks" disabled={laterBanDisabled}>
+              <div className="flex flex-col">
+                <span>{getBanScheduleLabel(2)}</span>
+                <span className="text-[10px] text-gray-500">
+                  {laterBanDisabled ? laterBanHelpText : `${laterBanHelpText} Pause after 2 picks.`}
+                </span>
+              </div>
+            </SelectItem>
+            <SelectItem value="after_3_picks" disabled={laterBanDisabled}>
+              <div className="flex flex-col">
+                <span>{getBanScheduleLabel(3)}</span>
+                <span className="text-[10px] text-gray-500">
+                  {laterBanDisabled ? laterBanHelpText : `${laterBanHelpText} Pause after 3 picks.`}
+                </span>
+              </div>
+            </SelectItem>
+            <SelectItem value="after_4_picks" disabled={laterBanDisabled}>
+              <div className="flex flex-col">
+                <span>{getBanScheduleLabel(4)}</span>
+                <span className="text-[10px] text-gray-500">
+                  {laterBanDisabled ? laterBanHelpText : `${laterBanHelpText} Pause after 4 picks.`}
+                </span>
+              </div>
+            </SelectItem>
+          </SelectContent>
+        </Select>
       </div>
+      <p className="w-full text-left text-[11px] text-gray-400">{banTimingSummary}</p>
       <Button
         variant={needsCaptains ? "secondary" : "outline"}
         size="sm"

--- a/src/app/draft/_lib/types.ts
+++ b/src/app/draft/_lib/types.ts
@@ -20,6 +20,7 @@ export interface DraftBan {
   team: 1 | 2;
   className: string;
   source?: "captain" | "auto";
+  phase?: "initial" | "deferred";
 }
 
 export interface DraftData {
@@ -46,11 +47,17 @@ export interface DraftData {
   firstRealmPickTeam?: 1 | 2;
   pickOrderMode?: "snake" | "alternating";
   bansPerCaptain?: number;
+  banTimingMode?: "before_picks" | "after_2_picks" | "after_3_picks" | "after_4_picks";
   safeClassNames?: string[];
   pickSequence?: (1 | 2)[];
   currentPickIndex?: number;
   banSequence?: (1 | 2)[];
+  initialBanSequence?: (1 | 2)[];
   currentBanIndex?: number;
+  activeBanPhase?: "initial" | "deferred";
+  deferredBanSequence?: (1 | 2)[];
+  deferredBanTriggerPickCount?: number;
+  deferredBanTriggered?: boolean;
   discordGuildId: string;
   discordGuildName?: string;
   discordChannelId: string;

--- a/src/app/test/draft/_components/DraftTestPageClient.tsx
+++ b/src/app/test/draft/_components/DraftTestPageClient.tsx
@@ -139,6 +139,7 @@ export default function DraftTestPageClient() {
           type: modePreset === "pvp" ? "pvp" : "traditional",
           teamSize: adjustedTeamSize,
           pickOrderMode: "alternating",
+          banTimingMode: "before_picks",
           token: creatorToken,
         });
       }
@@ -265,6 +266,10 @@ export default function DraftTestPageClient() {
           </p>
           <p className="text-xs text-gray-600 mt-2">
             Ban setting is per captain (for example, 3 means each captain gets 3 bans).
+          </p>
+          <p className="text-xs text-gray-600 mt-2">
+            In draft setup, Ban schedule shows the exact order. Example: with 2 bans, choose
+            1 before picks, 1 after 2 picks to ban once, pick two players, then ban again.
           </p>
         </div>
 

--- a/src/app/test/draft/page.tsx
+++ b/src/app/test/draft/page.tsx
@@ -1,9 +1,14 @@
 import dynamic from "next/dynamic";
+import ConvexClientProvider from "@/app/draft/_components/ConvexClientProvider";
 
 const DraftTestPageClient = dynamic(() => import("./_components/DraftTestPageClient"), {
   ssr: false,
 });
 
 export default function DraftTestPage() {
-  return <DraftTestPageClient />;
+  return (
+    <ConvexClientProvider>
+      <DraftTestPageClient />
+    </ConvexClientProvider>
+  );
 }

--- a/tests/draft.feature.test.ts
+++ b/tests/draft.feature.test.ts
@@ -219,6 +219,66 @@ test("undo from traditional banning with zero bans reverts only one realm pick",
   assert.equal(updated.firstPickTeam, 2);
 });
 
+test("re-picking realm after undo resets ban index before banning resumes", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "tradrepick",
+        status: "banning",
+        type: "traditional",
+        createdBy: "creator",
+        coinFlipChoice: "realm_first",
+        firstRealmPickTeam: 1,
+        firstPickTeam: 2,
+        team1CaptainId: "cap1",
+        team2CaptainId: "cap2",
+        team1Realm: "Albion",
+        team2Realm: "Midgard",
+        banSequence: [1, 2, 1, 2],
+        initialBanSequence: [1, 2, 1, 2],
+        currentBanIndex: 0,
+      },
+    ],
+    draftPlayers: [
+      { _id: "creator", draftId: "d1", token: "creator-token", discordUserId: "creator" },
+      { _id: "cap1", draftId: "d1", token: "cap1-token", discordUserId: "cap1" },
+      { _id: "cap2", draftId: "d1", token: "cap2-token", discordUserId: "cap2" },
+    ],
+    draftBans: [],
+  });
+
+  await (draftFns.undoLastAction as any)._handler(ctx, {
+    draftId: "d1",
+    token: "creator-token",
+  });
+
+  let draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "realm_pick");
+  assert.equal(draft.currentBanIndex, undefined);
+
+  await (draftFns.pickRealm as any)._handler(ctx, {
+    draftId: "d1",
+    token: "cap2-token",
+    realm: "Midgard",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "banning");
+  assert.equal(draft.currentBanIndex, 0);
+  assert.equal(draft.activeBanPhase, "initial");
+  assert.deepEqual(draft.banSequence, [1, 2, 1, 2]);
+
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    token: "cap1-token",
+    className: "Healer",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.currentBanIndex, 1);
+});
+
 test("startDraft with correct creator token transitions to coin_flip", async () => {
   const ctx = makeCtx({
     drafts: [
@@ -739,6 +799,434 @@ test("setCoinFlipChoice respects bansPerCaptain = 1 in pvp", async () => {
   assert.equal(updated.status, "banning");
   assert.deepEqual(updated.banSequence, [2, 1]);
   assert.equal(updated.currentBanIndex, 0);
+});
+
+test("setCoinFlipChoice splits bans when ban timing is after 2 picks", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "pvpsplit2",
+        status: "coin_flip",
+        type: "pvp",
+        teamSize: 4,
+        coinFlipWinnerId: "cap1",
+        team1CaptainId: "cap1",
+        team2CaptainId: "cap2",
+        createdBy: "creator",
+        bansPerCaptain: 3,
+        banTimingMode: "after_2_picks",
+      },
+    ],
+    draftPlayers: [
+      { _id: "cap1-player", draftId: "d1", token: "cap1-token", discordUserId: "cap1" },
+      { _id: "cap2-player", draftId: "d1", token: "cap2-token", discordUserId: "cap2" },
+    ],
+  });
+
+  await (draftFns.setCoinFlipChoice as any)._handler(ctx, {
+    draftId: "d1",
+    choice: "pick_first",
+    token: "cap1-token",
+  });
+
+  const updated = await ctx.db.get("d1");
+  assert.equal(updated.status, "banning");
+  assert.deepEqual(updated.banSequence, [2, 1]);
+  assert.deepEqual(updated.deferredBanSequence, [2, 1, 2, 1]);
+  assert.equal(updated.deferredBanTriggerPickCount, 2);
+  assert.equal(updated.deferredBanTriggered, false);
+  assert.equal(updated.activeBanPhase, "initial");
+});
+
+test("undo in deferred banning with zero deferred bans reverts triggering pick", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "pvpundodeferred",
+        status: "drafting",
+        type: "pvp",
+        teamSize: 4,
+        createdBy: "creator",
+        team1CaptainId: "cap1",
+        team2CaptainId: "cap2",
+        firstPickTeam: 1,
+        pickSequence: [1, 2, 1, 2, 1, 2],
+        currentPickIndex: 1,
+        banSequence: [2, 1],
+        currentBanIndex: 2,
+        deferredBanSequence: [2, 1],
+        deferredBanTriggerPickCount: 2,
+        deferredBanTriggered: false,
+      },
+    ],
+    draftPlayers: [
+      {
+        _id: "creator-player",
+        draftId: "d1",
+        token: "creator-token",
+        discordUserId: "creator",
+        isCaptain: false,
+      },
+      {
+        _id: "cap1-player",
+        draftId: "d1",
+        token: "cap1-token",
+        discordUserId: "cap1",
+        isCaptain: true,
+      },
+      {
+        _id: "cap2-player",
+        draftId: "d1",
+        token: "cap2-token",
+        discordUserId: "cap2",
+        isCaptain: true,
+      },
+      {
+        _id: "picked-1",
+        draftId: "d1",
+        token: "picked-1-token",
+        discordUserId: "p1",
+        isCaptain: false,
+        team: 1,
+        pickOrder: 1,
+      },
+      {
+        _id: "picked-2",
+        draftId: "d1",
+        token: "picked-2-token",
+        discordUserId: "p2",
+        isCaptain: false,
+      },
+    ],
+    draftBans: [
+      { _id: "ban-initial-1", draftId: "d1", team: 2, className: "Bard", source: "captain" },
+      { _id: "ban-initial-2", draftId: "d1", team: 1, className: "Druid", source: "captain" },
+    ],
+  });
+
+  await (draftFns.pickPlayer as any)._handler(ctx, {
+    draftId: "d1",
+    playerId: "picked-2",
+    token: "cap2-token",
+  });
+
+  const duringDeferred = await ctx.db.get("d1");
+  assert.equal(duringDeferred.status, "banning");
+  assert.equal(duringDeferred.activeBanPhase, "deferred");
+  assert.equal(duringDeferred.currentBanIndex, 0);
+  assert.equal(duringDeferred.currentPickIndex, 2);
+
+  await (draftFns.undoLastAction as any)._handler(ctx, {
+    draftId: "d1",
+    token: "creator-token",
+  });
+
+  const updated = await ctx.db.get("d1");
+  const revertedPlayer = await ctx.db.get("picked-2");
+  assert.equal(updated.status, "drafting");
+  assert.equal(updated.currentPickIndex, 1);
+  assert.equal(updated.deferredBanTriggered, false);
+  assert.equal(updated.activeBanPhase, undefined);
+  assert.equal(revertedPlayer.team, undefined);
+  assert.equal(revertedPlayer.pickOrder, undefined);
+});
+
+test("with 2 bans per captain, flow is 1 before picks then 1 after 2 picks", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "pvp2banssplit",
+        status: "coin_flip",
+        type: "pvp",
+        teamSize: 4,
+        coinFlipWinnerId: "cap1",
+        team1CaptainId: "cap1",
+        team2CaptainId: "cap2",
+        createdBy: "creator",
+        pickOrderMode: "alternating",
+        bansPerCaptain: 2,
+        banTimingMode: "after_2_picks",
+      },
+    ],
+    draftPlayers: [
+      { _id: "cap1-player", draftId: "d1", token: "cap1-token", discordUserId: "cap1", isCaptain: true },
+      { _id: "cap2-player", draftId: "d1", token: "cap2-token", discordUserId: "cap2", isCaptain: true },
+      { _id: "pick-1", draftId: "d1", token: "pick-1-token", discordUserId: "p1", isCaptain: false },
+      { _id: "pick-2", draftId: "d1", token: "pick-2-token", discordUserId: "p2", isCaptain: false },
+      { _id: "pick-3", draftId: "d1", token: "pick-3-token", discordUserId: "p3", isCaptain: false },
+      { _id: "pick-4", draftId: "d1", token: "pick-4-token", discordUserId: "p4", isCaptain: false },
+      { _id: "pick-5", draftId: "d1", token: "pick-5-token", discordUserId: "p5", isCaptain: false },
+      { _id: "pick-6", draftId: "d1", token: "pick-6-token", discordUserId: "p6", isCaptain: false },
+    ],
+  });
+
+  await (draftFns.setCoinFlipChoice as any)._handler(ctx, {
+    draftId: "d1",
+    choice: "pick_first",
+    token: "cap1-token",
+  });
+
+  let draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "banning");
+  assert.deepEqual(draft.banSequence, [2, 1]);
+  assert.deepEqual(draft.deferredBanSequence, [2, 1]);
+  assert.equal(draft.currentBanIndex, 0);
+
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Bard",
+    token: "cap2-token",
+  });
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Druid",
+    token: "cap1-token",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "drafting");
+  assert.equal(draft.currentPickIndex, 0);
+  assert.deepEqual(draft.pickSequence, [1, 2, 1, 2, 1, 2]);
+
+  await (draftFns.pickPlayer as any)._handler(ctx, {
+    draftId: "d1",
+    playerId: "pick-1",
+    token: "cap1-token",
+  });
+  await (draftFns.pickPlayer as any)._handler(ctx, {
+    draftId: "d1",
+    playerId: "pick-2",
+    token: "cap2-token",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "banning");
+  assert.equal(draft.activeBanPhase, "deferred");
+  assert.equal(draft.currentPickIndex, 2);
+  assert.equal(draft.currentBanIndex, 0);
+
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Healer",
+    token: "cap2-token",
+  });
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Warrior",
+    token: "cap1-token",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "drafting");
+  assert.equal(draft.currentPickIndex, 2);
+  assert.equal(draft.activeBanPhase, undefined);
+});
+
+test("split ban timing clamps trigger in small drafts", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "pvpclamp",
+        status: "coin_flip",
+        type: "pvp",
+        teamSize: 2,
+        coinFlipWinnerId: "cap1",
+        team1CaptainId: "cap1",
+        team2CaptainId: "cap2",
+        createdBy: "creator",
+        pickOrderMode: "alternating",
+        bansPerCaptain: 2,
+        banTimingMode: "after_4_picks",
+      },
+    ],
+    draftPlayers: [
+      { _id: "cap1-player", draftId: "d1", token: "cap1-token", discordUserId: "cap1", isCaptain: true },
+      { _id: "cap2-player", draftId: "d1", token: "cap2-token", discordUserId: "cap2", isCaptain: true },
+      { _id: "pick-1", draftId: "d1", token: "pick-1-token", discordUserId: "p1", isCaptain: false },
+      { _id: "pick-2", draftId: "d1", token: "pick-2-token", discordUserId: "p2", isCaptain: false },
+    ],
+  });
+
+  await (draftFns.setCoinFlipChoice as any)._handler(ctx, {
+    draftId: "d1",
+    choice: "pick_first",
+    token: "cap1-token",
+  });
+
+  let draft = await ctx.db.get("d1");
+  assert.equal(draft.deferredBanTriggerPickCount, 1);
+
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Bard",
+    token: "cap2-token",
+  });
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Druid",
+    token: "cap1-token",
+  });
+
+  await (draftFns.pickPlayer as any)._handler(ctx, {
+    draftId: "d1",
+    playerId: "pick-1",
+    token: "cap1-token",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "banning");
+  assert.equal(draft.currentPickIndex, 1);
+  assert.equal(draft.activeBanPhase, "deferred");
+});
+
+test("undo in deferred banning removes last deferred captain ban only", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "undodeferredban",
+        status: "banning",
+        type: "pvp",
+        createdBy: "creator",
+        currentBanIndex: 1,
+        activeBanPhase: "deferred",
+      },
+    ],
+    draftPlayers: [{ _id: "p1", draftId: "d1", token: "creator-token", discordUserId: "creator" }],
+    draftBans: [
+      {
+        _id: "initial-ban-1",
+        draftId: "d1",
+        team: 2,
+        className: "Bard",
+        source: "captain",
+        phase: "initial",
+      },
+      {
+        _id: "initial-ban-2",
+        draftId: "d1",
+        team: 1,
+        className: "Druid",
+        source: "captain",
+        phase: "initial",
+      },
+      {
+        _id: "deferred-ban-1",
+        draftId: "d1",
+        team: 2,
+        className: "Healer",
+        source: "captain",
+        phase: "deferred",
+      },
+    ],
+  });
+
+  await (draftFns.undoLastAction as any)._handler(ctx, {
+    draftId: "d1",
+    token: "creator-token",
+  });
+
+  const draft = await ctx.db.get("d1");
+  const bans = await ctx.db
+    .query("draftBans")
+    .withIndex("by_draft", (q: any) => q.eq("draftId", "d1"))
+    .collect();
+  assert.equal(draft.currentBanIndex, 0);
+  assert.equal(bans.length, 2);
+  assert.ok(bans.some((ban: any) => ban._id === "initial-ban-1"));
+  assert.ok(bans.some((ban: any) => ban._id === "initial-ban-2"));
+});
+
+test("undoing from deferred back to initial boundary restores initial ban sequence", async () => {
+  const ctx = makeCtx({
+    drafts: [
+      {
+        _id: "d1",
+        shortId: "restoreinitialseq",
+        status: "coin_flip",
+        type: "pvp",
+        teamSize: 4,
+        coinFlipWinnerId: "cap1",
+        team1CaptainId: "cap1",
+        team2CaptainId: "cap2",
+        createdBy: "creator",
+        pickOrderMode: "alternating",
+        bansPerCaptain: 3,
+        banTimingMode: "after_2_picks",
+      },
+    ],
+    draftPlayers: [
+      { _id: "creator-player", draftId: "d1", token: "creator-token", discordUserId: "creator", isCaptain: false },
+      { _id: "cap1-player", draftId: "d1", token: "cap1-token", discordUserId: "cap1", isCaptain: true },
+      { _id: "cap2-player", draftId: "d1", token: "cap2-token", discordUserId: "cap2", isCaptain: true },
+      { _id: "pick-1", draftId: "d1", token: "pick-1-token", discordUserId: "p1", isCaptain: false },
+      { _id: "pick-2", draftId: "d1", token: "pick-2-token", discordUserId: "p2", isCaptain: false },
+      { _id: "pick-3", draftId: "d1", token: "pick-3-token", discordUserId: "p3", isCaptain: false },
+      { _id: "pick-4", draftId: "d1", token: "pick-4-token", discordUserId: "p4", isCaptain: false },
+      { _id: "pick-5", draftId: "d1", token: "pick-5-token", discordUserId: "p5", isCaptain: false },
+      { _id: "pick-6", draftId: "d1", token: "pick-6-token", discordUserId: "p6", isCaptain: false },
+    ],
+  });
+
+  await (draftFns.setCoinFlipChoice as any)._handler(ctx, {
+    draftId: "d1",
+    choice: "pick_first",
+    token: "cap1-token",
+  });
+
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Bard",
+    token: "cap2-token",
+  });
+  await (draftFns.banClass as any)._handler(ctx, {
+    draftId: "d1",
+    className: "Druid",
+    token: "cap1-token",
+  });
+
+  await (draftFns.pickPlayer as any)._handler(ctx, {
+    draftId: "d1",
+    playerId: "pick-1",
+    token: "cap1-token",
+  });
+  await (draftFns.pickPlayer as any)._handler(ctx, {
+    draftId: "d1",
+    playerId: "pick-2",
+    token: "cap2-token",
+  });
+
+  let draft = await ctx.db.get("d1");
+  assert.deepEqual(draft.banSequence, [2, 1, 2, 1]);
+
+  await (draftFns.undoLastAction as any)._handler(ctx, {
+    draftId: "d1",
+    token: "creator-token",
+  });
+  await (draftFns.undoLastAction as any)._handler(ctx, {
+    draftId: "d1",
+    token: "creator-token",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "drafting");
+  assert.equal(draft.currentPickIndex, 0);
+  assert.deepEqual(draft.banSequence, [2, 1]);
+
+  await (draftFns.undoLastAction as any)._handler(ctx, {
+    draftId: "d1",
+    token: "creator-token",
+  });
+
+  draft = await ctx.db.get("d1");
+  assert.equal(draft.status, "banning");
+  assert.equal(draft.activeBanPhase, "initial");
+  assert.deepEqual(draft.banSequence, [2, 1]);
+  assert.equal(draft.currentBanIndex, 1);
 });
 
 test("traditional realm pick skips banning when bansPerCaptain is 0", async () => {


### PR DESCRIPTION
### Summary
Introduces creator-configurable ban timing: all bans before picks, or one ban round before picks with the rest after 2–4 total picks (clamped for small drafts). Server state tracks initialBanSequence, deferred sequence, phase, and ban phase so undo and deferred transitions stay consistent. Fixes realm re-pick leaving currentBanIndex unset, stale banSequence after deferred bans, and canUndo for deferred entry at ban index 0. Wraps the draft test page in ConvexClientProvider. Adds regression tests in tests/draft.feature.test.ts.