### PR TITLE
Add signed supporter-device grace and tune support modal cadence

### DIFF
--- a/src/app/_components/SupportPromptModal.tsx
+++ b/src/app/_components/SupportPromptModal.tsx
@@ -11,15 +11,10 @@ import { SUPPORT_PROMPT_TIER_PLANS } from "@/components/support/supportPromptTie
 import PaymentProviderToggle, {
   type PaymentProvider,
 } from "@/components/support/PaymentProviderToggle";
-import {
-  isKnownExemptActive,
-  shouldClearKnownExempt,
-  isSupportPromptEligible,
-} from "@/components/support/supportPromptRules";
+import { isSupportPromptEligible } from "@/components/support/supportPromptRules";
 
 const CLOSE_DELAY_SECONDS = 10;
-const KNOWN_EXEMPT_UNTIL_KEY = "divoxutils_support_prompt_known_exempt_until_v1";
-const KNOWN_EXEMPT_PERSIST_UNTIL = Number.MAX_SAFE_INTEGER;
+const LEGACY_KNOWN_EXEMPT_UNTIL_KEY = "divoxutils_support_prompt_known_exempt_until_v1";
 const CLOSE_LOCK_SUFFIX = "_close_lock_until_v1";
 const PENDING_TIER_KEY = "divoxutils_support_prompt_pending_tier_v1";
 const PENDING_PROVIDER_KEY = "divoxutils_support_prompt_pending_provider_v1";
@@ -36,6 +31,7 @@ type SupportPromptModalProps = {
   ignorePathRules?: boolean;
   isSupporter?: boolean;
   isAdmin?: boolean;
+  hasSupporterDeviceGrace?: boolean;
   paypalEnabled?: boolean;
 };
 
@@ -76,27 +72,10 @@ function writeHistory(storageKey: string, history: PromptHistory) {
   window.localStorage.setItem(storageKey, JSON.stringify(history));
 }
 
-function readKnownExemptUntil() {
-  if (typeof window === "undefined") return null;
-  try {
-    const raw = window.localStorage.getItem(KNOWN_EXEMPT_UNTIL_KEY);
-    if (!raw) return null;
-    const parsed = Number(raw);
-    if (!Number.isFinite(parsed)) return null;
-    return parsed;
-  } catch {
-    return null;
-  }
-}
-
-function writeKnownExemptUntil(timestamp: number | null) {
+function clearLegacyKnownExempt() {
   if (typeof window === "undefined") return;
   try {
-    if (!timestamp) {
-      window.localStorage.removeItem(KNOWN_EXEMPT_UNTIL_KEY);
-      return;
-    }
-    window.localStorage.setItem(KNOWN_EXEMPT_UNTIL_KEY, String(timestamp));
+    window.localStorage.removeItem(LEGACY_KNOWN_EXEMPT_UNTIL_KEY);
   } catch {
     return;
   }
@@ -198,6 +177,7 @@ export default function SupportPromptModal({
   ignorePathRules = false,
   isSupporter = false,
   isAdmin = false,
+  hasSupporterDeviceGrace = false,
   paypalEnabled = false,
 }: SupportPromptModalProps) {
   const checkoutErrorId = useId();
@@ -214,7 +194,6 @@ export default function SupportPromptModal({
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
   const [provider, setProvider] = useState<PaymentProvider>("stripe");
   const [history, setHistory] = useState<PromptHistory>(defaultHistory());
-  const [isKnownExempt, setIsKnownExempt] = useState(false);
   const cadence = useMemo(() => resolveCadence(Boolean(isSignedIn)), [isSignedIn]);
   const authState = isSignedIn ? "signed_in" : "signed_out";
 
@@ -248,7 +227,7 @@ export default function SupportPromptModal({
     isLoaded,
     isSupporter,
     isAdmin,
-    isKnownExempt,
+    hasSupporterDeviceGrace,
     ignorePathRules,
     pathname,
   });
@@ -342,39 +321,12 @@ export default function SupportPromptModal({
 
   useEffect(() => {
     if (!isLoaded) return;
-    const nowTimestamp = Date.now();
-    const knownExemptUntil = readKnownExemptUntil();
-    if (isKnownExemptActive(knownExemptUntil, nowTimestamp)) {
-      setIsKnownExempt(true);
-      return;
-    }
-    writeKnownExemptUntil(null);
-    setIsKnownExempt(false);
-  }, [isLoaded]);
-
-  useEffect(() => {
-    if (!isLoaded) return;
-    if (isSupporter || isAdmin) {
-      writeKnownExemptUntil(KNOWN_EXEMPT_PERSIST_UNTIL);
-      setIsKnownExempt(true);
-      return;
-    }
-    if (
-      shouldClearKnownExempt({
-        isSignedIn: Boolean(isSignedIn),
-        isSupporter,
-        isAdmin,
-      })
-    ) {
-      writeKnownExemptUntil(null);
-      setIsKnownExempt(false);
-      return;
-    }
-    const knownExemptUntil = readKnownExemptUntil();
-    if (!isKnownExemptActive(knownExemptUntil, Date.now())) {
-      writeKnownExemptUntil(null);
-      setIsKnownExempt(false);
-    }
+    clearLegacyKnownExempt();
+    if (!isSignedIn) return;
+    void fetch("/api/supporter-device", {
+      method: "POST",
+      credentials: "same-origin",
+    }).catch(() => undefined);
   }, [isLoaded, isSignedIn, isSupporter, isAdmin]);
 
   useEffect(() => {

--- a/src/app/api/supporter-device/route.ts
+++ b/src/app/api/supporter-device/route.ts
@@ -1,0 +1,73 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import prisma from "../../../../prisma/prismaClient";
+import { isAdminClerkUserId } from "@/server/adminAuth";
+import { createSupporterDeviceHandler } from "@/server/api/supporterDeviceRouteHandler";
+import {
+  createSupporterDeviceGraceCookieValue,
+  SUPPORTER_DEVICE_GRACE_COOKIE_NAME,
+  SUPPORTER_DEVICE_GRACE_MAX_AGE_SECONDS,
+} from "@/server/supporterDeviceGrace";
+
+export const runtime = "nodejs";
+
+const postHandler = createSupporterDeviceHandler({
+  getAuthUserId: async () => (await auth()).userId,
+  isAdminClerkUserId,
+  findUserByClerkId: (clerkUserId) =>
+    prisma.user.findUnique({
+      where: { clerkUserId },
+      select: {
+        supporterTier: true,
+        subscriptionStatus: true,
+        subscriptionCancelAtPeriodEnd: true,
+        subscriptionCurrentPeriodEnd: true,
+      },
+    }),
+  createCookieValue: () => createSupporterDeviceGraceCookieValue(),
+});
+
+const methodNotAllowed = () => NextResponse.json({ error: "Method not allowed" }, { status: 405 });
+
+export async function POST(request: Request) {
+  const result = await postHandler({ method: request.method });
+  const response = NextResponse.json(result.body, { status: result.status });
+
+  if (result.cookieAction === "set" && result.cookieValue) {
+    response.cookies.set(SUPPORTER_DEVICE_GRACE_COOKIE_NAME, result.cookieValue, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: SUPPORTER_DEVICE_GRACE_MAX_AGE_SECONDS,
+    });
+  }
+
+  if (result.cookieAction === "clear") {
+    response.cookies.set(SUPPORTER_DEVICE_GRACE_COOKIE_NAME, "", {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === "production",
+      sameSite: "lax",
+      path: "/",
+      maxAge: 0,
+    });
+  }
+
+  return response;
+}
+
+export async function GET() {
+  return methodNotAllowed();
+}
+
+export async function PUT() {
+  return methodNotAllowed();
+}
+
+export async function PATCH() {
+  return methodNotAllowed();
+}
+
+export async function DELETE() {
+  return methodNotAllowed();
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -44,7 +44,7 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const { isSupporter, isAdmin } = await getLayoutViewerContext();
+  const { isSupporter, isAdmin, hasSupporterDeviceGrace } = await getLayoutViewerContext();
   const paypalEnabled = isPayPalSubscriptionsEnabled();
 
   return (
@@ -74,9 +74,10 @@ export default async function RootLayout({
               <SupportPromptModal
                 isSupporter={isSupporter}
                 isAdmin={isAdmin}
+                hasSupporterDeviceGrace={hasSupporterDeviceGrace}
                 paypalEnabled={paypalEnabled}
               />
-              <SignedOutNudge />
+              <SignedOutNudge hasSupporterDeviceGrace={hasSupporterDeviceGrace} />
               <main id="main-content" className="flex-1 focus:outline-none" tabIndex={-1}>
                 {children}
               </main>

--- a/src/components/auth/SignedOutNudge.tsx
+++ b/src/components/auth/SignedOutNudge.tsx
@@ -13,7 +13,13 @@ const DISMISS_MS = 24 * 60 * 60 * 1000;
 const isAuthPage = (pathname: string | null) =>
   pathname?.startsWith("/sign-in") || pathname?.startsWith("/sign-up");
 
-export default function SignedOutNudge() {
+type SignedOutNudgeProps = {
+  hasSupporterDeviceGrace?: boolean;
+};
+
+export default function SignedOutNudge({
+  hasSupporterDeviceGrace = false,
+}: SignedOutNudgeProps) {
   const { isSignedIn } = useAuth();
   const pathname = usePathname();
   const [visible, setVisible] = useState(false);
@@ -44,9 +50,10 @@ export default function SignedOutNudge() {
     const dismissedUntilRaw = window.localStorage.getItem(DISMISSED_UNTIL_KEY);
     const dismissedUntil = dismissedUntilRaw ? Number(dismissedUntilRaw) : 0;
     const now = Date.now();
+    const canShowForDevice = hasSupporterDeviceGrace || hadSession || isLocalhost;
 
     if (
-      (!hadSession && !isLocalhost) ||
+      !canShowForDevice ||
       Number.isNaN(dismissedUntil) ||
       (!isLocalhost && now < dismissedUntil)
     ) {
@@ -55,7 +62,7 @@ export default function SignedOutNudge() {
     }
 
     setVisible(true);
-  }, [isSignedIn, pathname]);
+  }, [isSignedIn, pathname, hasSupporterDeviceGrace]);
 
   const signInHref = useMemo(() => {
     const redirect = pathname || "/";
@@ -74,7 +81,7 @@ export default function SignedOutNudge() {
     <div className="fixed bottom-4 left-1/2 z-50 w-[calc(100%-2rem)] max-w-sm -translate-x-1/2 sm:left-auto sm:right-5 sm:w-auto sm:translate-x-0">
       <div className="flex items-center gap-3 rounded-lg border border-gray-700 bg-gray-800 py-2.5 pl-4 pr-2 shadow-xl">
         <p className="min-w-0 text-[13px] leading-snug text-gray-300">
-          Signed out &mdash; your preferences and supporter perks won&rsquo;t apply
+          Signed out &mdash; sign in to keep your preferences and account status active
         </p>
         <Link
           href={signInHref}

--- a/src/components/support/supportPromptCadence.ts
+++ b/src/components/support/supportPromptCadence.ts
@@ -1,7 +1,7 @@
 const STORAGE_KEY = "divoxutils_support_prompt_v2_non_supporter_device";
 const WINDOW_DAYS = 7;
-const MAX_IMPRESSIONS = 5;
-const MIN_INTERVAL_HOURS = 24;
+const MAX_IMPRESSIONS = 6;
+const MIN_INTERVAL_HOURS = 20;
 
 export function resolveCadence(_isSignedIn: boolean) {
   const windowDays = WINDOW_DAYS;

--- a/src/components/support/supportPromptRules.ts
+++ b/src/components/support/supportPromptRules.ts
@@ -14,46 +14,21 @@ export function isSupportPromptEligible({
   isLoaded,
   isSupporter,
   isAdmin,
-  isKnownExempt,
+  hasSupporterDeviceGrace,
   ignorePathRules,
   pathname,
 }: {
   isLoaded: boolean;
   isSupporter: boolean;
   isAdmin: boolean;
-  isKnownExempt: boolean;
+  hasSupporterDeviceGrace: boolean;
   ignorePathRules: boolean;
   pathname: string | null;
 }) {
   if (!isLoaded) return false;
   if (isSupporter) return false;
   if (isAdmin) return false;
-  if (isKnownExempt) return false;
+  if (hasSupporterDeviceGrace) return false;
   if (ignorePathRules) return true;
   return !isSupportPromptExcludedPath(pathname);
-}
-
-export function isKnownExemptActive(
-  knownExemptUntil: number | null,
-  now: number
-) {
-  if (
-    typeof knownExemptUntil !== "number" ||
-    !Number.isFinite(knownExemptUntil)
-  ) {
-    return false;
-  }
-  return knownExemptUntil > now;
-}
-
-export function shouldClearKnownExempt({
-  isSignedIn,
-  isSupporter,
-  isAdmin,
-}: {
-  isSignedIn: boolean;
-  isSupporter: boolean;
-  isAdmin: boolean;
-}) {
-  return isSignedIn && !isSupporter && !isAdmin;
 }

--- a/src/server/api/supporterDeviceRouteHandler.ts
+++ b/src/server/api/supporterDeviceRouteHandler.ts
@@ -1,0 +1,81 @@
+import { isEffectivelySupporter } from "@/server/supporterStatus";
+
+type SupporterDeviceUser = {
+  supporterTier: number | null;
+  subscriptionStatus: string | null;
+  subscriptionCancelAtPeriodEnd: boolean | null;
+  subscriptionCurrentPeriodEnd: Date | null;
+};
+
+type SupporterDeviceDeps = {
+  getAuthUserId: () => Promise<string | null> | string | null;
+  isAdminClerkUserId: (clerkUserId: string | null | undefined) => boolean;
+  findUserByClerkId: (clerkUserId: string) => Promise<SupporterDeviceUser | null>;
+  createCookieValue: () => string | null;
+};
+
+type SupporterDeviceRequestInput = {
+  method: string;
+};
+
+export type SupporterDeviceResponse = {
+  status: 200 | 401 | 405 | 500;
+  body: {
+    hasSupporterDeviceGrace: boolean;
+    error?: string;
+  };
+  cookieAction: "set" | "clear" | "none";
+  cookieValue?: string;
+};
+
+export const createSupporterDeviceHandler =
+  (deps: SupporterDeviceDeps) =>
+  async (input: SupporterDeviceRequestInput): Promise<SupporterDeviceResponse> => {
+    if (input.method !== "POST") {
+      return {
+        status: 405,
+        body: { hasSupporterDeviceGrace: false, error: "Method not allowed" },
+        cookieAction: "none",
+      };
+    }
+
+    const clerkUserId = await deps.getAuthUserId();
+    if (!clerkUserId) {
+      return {
+        status: 401,
+        body: { hasSupporterDeviceGrace: false, error: "Unauthorized" },
+        cookieAction: "none",
+      };
+    }
+
+    const isAdmin = deps.isAdminClerkUserId(clerkUserId);
+    const user = isAdmin ? null : await deps.findUserByClerkId(clerkUserId);
+    const hasSupporterAccess = isAdmin || isEffectivelySupporter(user);
+
+    if (!hasSupporterAccess) {
+      return {
+        status: 200,
+        body: { hasSupporterDeviceGrace: false },
+        cookieAction: "clear",
+      };
+    }
+
+    const cookieValue = deps.createCookieValue();
+    if (!cookieValue) {
+      return {
+        status: 500,
+        body: {
+          hasSupporterDeviceGrace: false,
+          error: "Supporter device grace is misconfigured.",
+        },
+        cookieAction: "none",
+      };
+    }
+
+    return {
+      status: 200,
+      body: { hasSupporterDeviceGrace: true },
+      cookieAction: "set",
+      cookieValue,
+    };
+  };

--- a/src/server/layoutViewerContext.ts
+++ b/src/server/layoutViewerContext.ts
@@ -1,16 +1,24 @@
 import { auth } from "@clerk/nextjs/server";
+import { cookies } from "next/headers";
 import prisma from "../../prisma/prismaClient";
 import { isAdminClerkUserId } from "@/server/adminAuth";
 import { isEffectivelySupporter } from "@/server/supporterStatus";
+import {
+  getSupporterDeviceGraceSecret,
+  SUPPORTER_DEVICE_GRACE_COOKIE_NAME,
+  verifySupporterDeviceGraceValue,
+} from "@/server/supporterDeviceGrace";
 
 export type LayoutViewerContext = {
   isSupporter: boolean;
   isAdmin: boolean;
+  hasSupporterDeviceGrace: boolean;
 };
 
 export async function getLayoutViewerContext(): Promise<LayoutViewerContext> {
   let isSupporter = false;
   let isAdmin = false;
+  let hasSupporterDeviceGrace = false;
 
   try {
     const { userId } = await auth();
@@ -26,11 +34,18 @@ export async function getLayoutViewerContext(): Promise<LayoutViewerContext> {
         },
       });
       isSupporter = isEffectivelySupporter(user);
+    } else {
+      const cookieValue = cookies().get(SUPPORTER_DEVICE_GRACE_COOKIE_NAME)?.value;
+      hasSupporterDeviceGrace = verifySupporterDeviceGraceValue({
+        value: cookieValue,
+        secret: getSupporterDeviceGraceSecret(),
+      });
     }
   } catch {
     isSupporter = false;
     isAdmin = false;
+    hasSupporterDeviceGrace = false;
   }
 
-  return { isSupporter, isAdmin };
+  return { isSupporter, isAdmin, hasSupporterDeviceGrace };
 }

--- a/src/server/supporterDeviceGrace.ts
+++ b/src/server/supporterDeviceGrace.ts
@@ -1,0 +1,70 @@
+import crypto from "crypto";
+
+export const SUPPORTER_DEVICE_GRACE_COOKIE_NAME = "du_supporter_grace_v1";
+export const SUPPORTER_DEVICE_GRACE_TTL_MS = 14 * 24 * 60 * 60 * 1000;
+export const SUPPORTER_DEVICE_GRACE_MAX_AGE_SECONDS = SUPPORTER_DEVICE_GRACE_TTL_MS / 1000;
+
+type CreateSupporterDeviceGraceValueInput = {
+  expiresAt: number;
+  secret: string;
+};
+
+type VerifySupporterDeviceGraceValueInput = {
+  value: string | null | undefined;
+  secret: string | null | undefined;
+  now?: number;
+};
+
+function signPayload(payload: string, secret: string) {
+  return crypto.createHmac("sha256", secret).update(payload).digest("base64url");
+}
+
+function safeEqual(left: string, right: string) {
+  const leftBuffer = Buffer.from(left);
+  const rightBuffer = Buffer.from(right);
+  if (leftBuffer.length !== rightBuffer.length) return false;
+  return crypto.timingSafeEqual(leftBuffer, rightBuffer);
+}
+
+export function getSupporterDeviceGraceSecret() {
+  return (
+    process.env.SUPPORTER_DEVICE_COOKIE_SECRET ??
+    process.env.CLERK_SECRET_KEY ??
+    process.env.JWT_SECRET ??
+    null
+  );
+}
+
+export function createSupporterDeviceGraceValue({
+  expiresAt,
+  secret,
+}: CreateSupporterDeviceGraceValueInput) {
+  const payload = `v1.${expiresAt}`;
+  return `${payload}.${signPayload(payload, secret)}`;
+}
+
+export function createSupporterDeviceGraceCookieValue(now = Date.now()) {
+  const secret = getSupporterDeviceGraceSecret();
+  if (!secret) return null;
+  return createSupporterDeviceGraceValue({
+    expiresAt: now + SUPPORTER_DEVICE_GRACE_TTL_MS,
+    secret,
+  });
+}
+
+export function verifySupporterDeviceGraceValue({
+  value,
+  secret,
+  now = Date.now(),
+}: VerifySupporterDeviceGraceValueInput) {
+  if (!value || !secret) return false;
+  const parts = value.split(".");
+  if (parts.length !== 3) return false;
+  const [version, expiresAtRaw, signature] = parts;
+  if (version !== "v1") return false;
+  const expiresAt = Number(expiresAtRaw);
+  if (!Number.isFinite(expiresAt) || expiresAt <= now) return false;
+  const payload = `${version}.${expiresAtRaw}`;
+  const expectedSignature = signPayload(payload, secret);
+  return safeEqual(signature, expectedSignature);
+}

--- a/tests/src-structure.cleanup.test.ts
+++ b/tests/src-structure.cleanup.test.ts
@@ -15,6 +15,16 @@ test("shared components are not sourced from app components", () => {
   assert.equal(signedOutNudgeSource.includes("@/app/components/"), false);
 });
 
+test("supporter device grace is wired through layout and signed-out nudge", () => {
+  const layoutSource = readFileSync("src/app/layout.tsx", "utf8");
+  const modalSource = readFileSync("src/app/_components/SupportPromptModal.tsx", "utf8");
+  const signedOutNudgeSource = readFileSync("src/components/auth/SignedOutNudge.tsx", "utf8");
+
+  assert.equal(layoutSource.includes("hasSupporterDeviceGrace={hasSupporterDeviceGrace}"), true);
+  assert.equal(modalSource.includes("hasSupporterDeviceGrace"), true);
+  assert.equal(signedOutNudgeSource.includes("hasSupporterDeviceGrace"), true);
+});
+
 test("legacy app component wrappers are removed", () => {
   assert.equal(existsSync("src/app/components/SupporterBadge.tsx"), false);
   assert.equal(existsSync("src/app/components/SignedOutNudge.tsx"), false);

--- a/tests/support-prompt-cadence.test.ts
+++ b/tests/support-prompt-cadence.test.ts
@@ -8,16 +8,16 @@ import {
 test("resolveCadence returns unified cadence config for signed-in users", () => {
   const cadence = resolveCadence(true);
   assert.equal(cadence.windowDays, 7);
-  assert.equal(cadence.maxImpressions, 5);
-  assert.equal(cadence.minIntervalMs, 24 * 60 * 60 * 1000);
+  assert.equal(cadence.maxImpressions, 6);
+  assert.equal(cadence.minIntervalMs, 20 * 60 * 60 * 1000);
   assert.equal(cadence.storageKey, "divoxutils_support_prompt_v2_non_supporter_device");
 });
 
 test("resolveCadence returns unified cadence config for signed-out users", () => {
   const cadence = resolveCadence(false);
   assert.equal(cadence.windowDays, 7);
-  assert.equal(cadence.maxImpressions, 5);
-  assert.equal(cadence.minIntervalMs, 24 * 60 * 60 * 1000);
+  assert.equal(cadence.maxImpressions, 6);
+  assert.equal(cadence.minIntervalMs, 20 * 60 * 60 * 1000);
   assert.equal(cadence.storageKey, "divoxutils_support_prompt_v2_non_supporter_device");
 });
 

--- a/tests/support-prompt-rules.test.ts
+++ b/tests/support-prompt-rules.test.ts
@@ -1,8 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import {
-  isKnownExemptActive,
-  shouldClearKnownExempt,
   isSupportPromptEligible,
   isSupportPromptExcludedPath,
 } from "../src/components/support/supportPromptRules";
@@ -30,7 +28,7 @@ test("isSupportPromptEligible blocks non-eligible states", () => {
       isLoaded: false,
       isSupporter: false,
       isAdmin: false,
-      isKnownExempt: false,
+      hasSupporterDeviceGrace: false,
       ignorePathRules: false,
       pathname: "/user/cameron/characters",
     }),
@@ -41,7 +39,7 @@ test("isSupportPromptEligible blocks non-eligible states", () => {
       isLoaded: true,
       isSupporter: true,
       isAdmin: false,
-      isKnownExempt: false,
+      hasSupporterDeviceGrace: false,
       ignorePathRules: false,
       pathname: "/user/cameron/characters",
     }),
@@ -52,7 +50,7 @@ test("isSupportPromptEligible blocks non-eligible states", () => {
       isLoaded: true,
       isSupporter: false,
       isAdmin: true,
-      isKnownExempt: false,
+      hasSupporterDeviceGrace: false,
       ignorePathRules: false,
       pathname: "/user/cameron/characters",
     }),
@@ -63,7 +61,7 @@ test("isSupportPromptEligible blocks non-eligible states", () => {
       isLoaded: true,
       isSupporter: false,
       isAdmin: false,
-      isKnownExempt: true,
+      hasSupporterDeviceGrace: true,
       ignorePathRules: false,
       pathname: "/user/cameron/characters",
     }),
@@ -74,7 +72,7 @@ test("isSupportPromptEligible blocks non-eligible states", () => {
       isLoaded: true,
       isSupporter: false,
       isAdmin: false,
-      isKnownExempt: false,
+      hasSupporterDeviceGrace: false,
       ignorePathRules: false,
       pathname: "/contribute",
     }),
@@ -88,7 +86,7 @@ test("isSupportPromptEligible allows normal path and ignorePathRules override", 
       isLoaded: true,
       isSupporter: false,
       isAdmin: false,
-      isKnownExempt: false,
+      hasSupporterDeviceGrace: false,
       ignorePathRules: false,
       pathname: "/user/cameron/characters",
     }),
@@ -99,54 +97,10 @@ test("isSupportPromptEligible allows normal path and ignorePathRules override", 
       isLoaded: true,
       isSupporter: false,
       isAdmin: false,
-      isKnownExempt: false,
+      hasSupporterDeviceGrace: false,
       ignorePathRules: true,
       pathname: "/contribute",
     }),
     true
-  );
-});
-
-test("isKnownExemptActive validates timestamps safely", () => {
-  const now = Date.UTC(2026, 2, 28, 0, 0, 0);
-  assert.equal(isKnownExemptActive(now + 1, now), true);
-  assert.equal(isKnownExemptActive(now, now), false);
-  assert.equal(isKnownExemptActive(now - 1, now), false);
-  assert.equal(isKnownExemptActive(null, now), false);
-  assert.equal(isKnownExemptActive(Number.NaN, now), false);
-});
-
-test("shouldClearKnownExempt clears immediately for signed-in non-supporters", () => {
-  assert.equal(
-    shouldClearKnownExempt({
-      isSignedIn: true,
-      isSupporter: false,
-      isAdmin: false,
-    }),
-    true
-  );
-  assert.equal(
-    shouldClearKnownExempt({
-      isSignedIn: false,
-      isSupporter: false,
-      isAdmin: false,
-    }),
-    false
-  );
-  assert.equal(
-    shouldClearKnownExempt({
-      isSignedIn: true,
-      isSupporter: true,
-      isAdmin: false,
-    }),
-    false
-  );
-  assert.equal(
-    shouldClearKnownExempt({
-      isSignedIn: true,
-      isSupporter: false,
-      isAdmin: true,
-    }),
-    false
   );
 });

--- a/tests/supporter-device-grace.test.ts
+++ b/tests/supporter-device-grace.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createSupporterDeviceGraceValue,
+  SUPPORTER_DEVICE_GRACE_COOKIE_NAME,
+  SUPPORTER_DEVICE_GRACE_TTL_MS,
+  verifySupporterDeviceGraceValue,
+} from "../src/server/supporterDeviceGrace";
+
+test("supporter device grace cookie constants are stable", () => {
+  assert.equal(SUPPORTER_DEVICE_GRACE_COOKIE_NAME, "du_supporter_grace_v1");
+  assert.equal(SUPPORTER_DEVICE_GRACE_TTL_MS, 14 * 24 * 60 * 60 * 1000);
+});
+
+test("verifySupporterDeviceGraceValue accepts valid unexpired values", () => {
+  const now = Date.UTC(2026, 3, 29, 12, 0, 0);
+  const value = createSupporterDeviceGraceValue({
+    expiresAt: now + 1000,
+    secret: "test-secret",
+  });
+
+  assert.equal(
+    verifySupporterDeviceGraceValue({
+      value,
+      secret: "test-secret",
+      now,
+    }),
+    true
+  );
+});
+
+test("verifySupporterDeviceGraceValue rejects expired, tampered, and unsigned values", () => {
+  const now = Date.UTC(2026, 3, 29, 12, 0, 0);
+  const value = createSupporterDeviceGraceValue({
+    expiresAt: now + 1000,
+    secret: "test-secret",
+  });
+  const tampered = value.replace("v1.", "v1.9");
+  const expired = createSupporterDeviceGraceValue({
+    expiresAt: now,
+    secret: "test-secret",
+  });
+
+  assert.equal(
+    verifySupporterDeviceGraceValue({
+      value: tampered,
+      secret: "test-secret",
+      now,
+    }),
+    false
+  );
+  assert.equal(
+    verifySupporterDeviceGraceValue({
+      value: expired,
+      secret: "test-secret",
+      now,
+    }),
+    false
+  );
+  assert.equal(
+    verifySupporterDeviceGraceValue({
+      value,
+      secret: "wrong-secret",
+      now,
+    }),
+    false
+  );
+  assert.equal(
+    verifySupporterDeviceGraceValue({
+      value,
+      secret: null,
+      now,
+    }),
+    false
+  );
+});

--- a/tests/supporter-device-route.test.ts
+++ b/tests/supporter-device-route.test.ts
@@ -1,0 +1,91 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createSupporterDeviceHandler } from "../src/server/api/supporterDeviceRouteHandler";
+
+const activeSupporter = {
+  supporterTier: 0,
+  subscriptionStatus: "active",
+  subscriptionCancelAtPeriodEnd: false,
+  subscriptionCurrentPeriodEnd: null,
+};
+
+test("supporter device route requires POST and auth", async () => {
+  const handler = createSupporterDeviceHandler({
+    getAuthUserId: async () => null,
+    isAdminClerkUserId: () => false,
+    findUserByClerkId: async () => null,
+    createCookieValue: () => "cookie-value",
+  });
+
+  const methodResult = await handler({ method: "GET" });
+  assert.equal(methodResult.status, 405);
+  assert.equal(methodResult.cookieAction, "none");
+
+  const authResult = await handler({ method: "POST" });
+  assert.equal(authResult.status, 401);
+  assert.equal(authResult.cookieAction, "none");
+});
+
+test("supporter device route sets cookie for active supporters and admins", async () => {
+  const supporterHandler = createSupporterDeviceHandler({
+    getAuthUserId: async () => "user_supporter",
+    isAdminClerkUserId: () => false,
+    findUserByClerkId: async () => activeSupporter,
+    createCookieValue: () => "supporter-cookie",
+  });
+  const supporterResult = await supporterHandler({ method: "POST" });
+  assert.equal(supporterResult.status, 200);
+  assert.equal(supporterResult.body.hasSupporterDeviceGrace, true);
+  assert.equal(supporterResult.cookieAction, "set");
+  assert.equal(supporterResult.cookieValue, "supporter-cookie");
+
+  let lookupCalls = 0;
+  const adminHandler = createSupporterDeviceHandler({
+    getAuthUserId: async () => "user_admin",
+    isAdminClerkUserId: () => true,
+    findUserByClerkId: async () => {
+      lookupCalls += 1;
+      return null;
+    },
+    createCookieValue: () => "admin-cookie",
+  });
+  const adminResult = await adminHandler({ method: "POST" });
+  assert.equal(adminResult.status, 200);
+  assert.equal(adminResult.body.hasSupporterDeviceGrace, true);
+  assert.equal(adminResult.cookieAction, "set");
+  assert.equal(adminResult.cookieValue, "admin-cookie");
+  assert.equal(lookupCalls, 0);
+});
+
+test("supporter device route clears cookie for signed-in non-supporters", async () => {
+  const handler = createSupporterDeviceHandler({
+    getAuthUserId: async () => "user_free",
+    isAdminClerkUserId: () => false,
+    findUserByClerkId: async () => ({
+      supporterTier: 0,
+      subscriptionStatus: "canceled",
+      subscriptionCancelAtPeriodEnd: false,
+      subscriptionCurrentPeriodEnd: null,
+    }),
+    createCookieValue: () => "cookie-value",
+  });
+
+  const result = await handler({ method: "POST" });
+  assert.equal(result.status, 200);
+  assert.equal(result.body.hasSupporterDeviceGrace, false);
+  assert.equal(result.cookieAction, "clear");
+});
+
+test("supporter device route reports misconfiguration when cookie cannot be signed", async () => {
+  const handler = createSupporterDeviceHandler({
+    getAuthUserId: async () => "user_supporter",
+    isAdminClerkUserId: () => false,
+    findUserByClerkId: async () => activeSupporter,
+    createCookieValue: () => null,
+  });
+
+  const result = await handler({ method: "POST" });
+  assert.equal(result.status, 500);
+  assert.equal(result.cookieAction, "none");
+  assert.equal(result.body.hasSupporterDeviceGrace, false);
+});


### PR DESCRIPTION
### Changes
- Add signed du_supporter_grace_v1 cookie flow to preserve supporter/admin modal exemption across Clerk session expiry.
- Add /api/supporter-device sync endpoint to refresh grace for active supporters/admins and clear it for non-supporters.
- Wire hasSupporterDeviceGrace through layout, modal, and signed-out nudge; remove permanent localStorage exemption path.
- Increase non-supporter prompt cadence to 6 per 7 days with 20h minimum interval.
- Add tests for cookie signing/verification, route behavior, rules updates, cadence changes, and layout wiring.