### PR TITLE
Reveal weekly kill stats

### DIFF
--- a/src/app/_components/characters/RecentActivity.tsx
+++ b/src/app/_components/characters/RecentActivity.tsx
@@ -23,6 +23,7 @@ type ActivityRow = {
   realm: string;
   className: string;
   rp: number;
+  kills: number;
   deathBlows: number | null;
   soloKills: number;
   deaths: number;
@@ -57,6 +58,11 @@ function deriveThisWeek(character: CharacterData): Omit<ActivityRow, "id" | "nam
     character.totalDeathBlows,
     character.deathBlowsLastWeek
   );
+  const kills = deriveDelta(
+    character.heraldTotalKills,
+    character.totalKills,
+    character.killsLastWeek
+  ) ?? 0;
   const soloKills = deriveDelta(
     character.heraldTotalSoloKills,
     character.totalSoloKills,
@@ -67,12 +73,13 @@ function deriveThisWeek(character: CharacterData): Omit<ActivityRow, "id" | "nam
     character.totalDeaths,
     character.deathsLastWeek
   ) ?? 0;
-  return { rp, deathBlows, soloKills, deaths };
+  return { rp, kills, deathBlows, soloKills, deaths };
 }
 
 function deriveLastWeek(character: CharacterData): Omit<ActivityRow, "id" | "name" | "realm" | "className"> {
   return {
     rp: Math.max(0, character.realmPointsLastWeek ?? 0),
+    kills: Math.max(0, character.killsLastWeek ?? 0),
     deathBlows: Math.max(0, character.deathBlowsLastWeek ?? 0),
     soloKills: Math.max(0, character.soloKillsLastWeek ?? 0),
     deaths: Math.max(0, character.deathsLastWeek ?? 0),
@@ -85,13 +92,14 @@ const STAT_LABELS = [
     label: "RPs",
     cellClass: "pr-3 border-r border-gray-800/80",
   },
+  { key: "kills" as const, label: "Kills", cellClass: "" },
   { key: "deathBlows" as const, label: "DBs", cellClass: "" },
   { key: "soloKills" as const, label: "SKs", cellClass: "" },
   { key: "deaths" as const, label: "Deaths", cellClass: "" },
 ];
 
 const ACTIVITY_GRID_CLASS =
-  "grid grid-cols-[minmax(0,1fr)_5.5rem_2.75rem_2.75rem_3.25rem] sm:grid-cols-[minmax(0,1fr)_6rem_3rem_3rem_3.5rem] gap-2";
+  "grid grid-cols-[minmax(0,1fr)_5.25rem_3rem_2.75rem_2.75rem_3.25rem] sm:grid-cols-[minmax(0,1fr)_6rem_3.25rem_3rem_3rem_3.5rem] gap-2";
 
 const RecentActivity: React.FC<RecentActivityProps> = ({ characters }) => {
   const [period, setPeriod] = useState<ActivityPeriod>("thisWeek");
@@ -120,6 +128,7 @@ const RecentActivity: React.FC<RecentActivityProps> = ({ characters }) => {
   const activeRows = sortedRows.filter(
     (row) =>
       row.rp > 0 ||
+      row.kills > 0 ||
       (row.deathBlows ?? 0) > 0 ||
       row.soloKills > 0 ||
       row.deaths > 0

--- a/src/app/leaderboards/_components/LeaderboardList.tsx
+++ b/src/app/leaderboards/_components/LeaderboardList.tsx
@@ -110,8 +110,6 @@ const LeaderboardList: React.FC<LeaderboardListProps> = ({ data }) => {
   const [currentPage, setCurrentPage] = useState<number>(
     Number.isNaN(initialPage) || initialPage < 1 ? 1 : initialPage
   );
-  const isWeeklyKillsUnavailable =
-    selectedMetric === "kills" && selectedPeriod !== "total";
 
   const processedData = useMemo(() => {
     return data.map((item) => {
@@ -206,84 +204,71 @@ const LeaderboardList: React.FC<LeaderboardListProps> = ({ data }) => {
         </div>
       </div>
 
-      {isWeeklyKillsUnavailable ? (
-        <div className="rounded-md border border-gray-800 bg-gray-900/60 px-4 py-8 text-center">
-          <p className="text-sm font-medium text-gray-300">
-            Weekly kill rankings are coming next week.
-          </p>
-          <p className="mt-1 text-xs text-gray-500">
-            Total kills are available now.
-          </p>
-        </div>
-      ) : (
-        <>
-          <ol className="space-y-2">
-            {paginatedData.map((item, index) => {
-              const metricKey =
-                selectedPeriod === "total"
-                  ? `total${capitalize(selectedMetric)}`
-                  : `${selectedMetric}${capitalize(selectedPeriod)}`;
-              const value = item[metricKey] as number | undefined;
+      <ol className="space-y-2">
+        {paginatedData.map((item, index) => {
+          const metricKey =
+            selectedPeriod === "total"
+              ? `total${capitalize(selectedMetric)}`
+              : `${selectedMetric}${capitalize(selectedPeriod)}`;
+          const value = item[metricKey] as number | undefined;
 
-              const startIndex = (currentPage - 1) * itemsPerPage;
-              const globalRank = startIndex + index + 1;
-              const isTopFive = index < 5;
-              const LinkComponent = isTopFive
-                ? HoverPrefetchLink
-                : ViewportPrefetchLink;
+          const startIndex = (currentPage - 1) * itemsPerPage;
+          const globalRank = startIndex + index + 1;
+          const isTopFive = index < 5;
+          const LinkComponent = isTopFive
+            ? HoverPrefetchLink
+            : ViewportPrefetchLink;
 
-              const rankBadge =
-                globalRank === 1
-                  ? "bg-indigo-500/30 text-indigo-300"
-                  : globalRank === 2
-                    ? "bg-indigo-500/20 text-indigo-300"
-                    : globalRank === 3
-                      ? "bg-indigo-500/10 text-indigo-400/70"
-                      : "bg-gray-800 text-gray-500";
+          const rankBadge =
+            globalRank === 1
+              ? "bg-indigo-500/30 text-indigo-300"
+              : globalRank === 2
+                ? "bg-indigo-500/20 text-indigo-300"
+                : globalRank === 3
+                  ? "bg-indigo-500/10 text-indigo-400/70"
+                  : "bg-gray-800 text-gray-500";
 
-              return (
-                <li
-                  key={item.userId}
-                  className={`group rounded-md border border-gray-800 hover:border-gray-700 hover:bg-gray-800/40 transition-colors duration-150 relative overflow-hidden ${supporterRowClass(item.supporterTier)}`}
-                >
-                  <LinkComponent
-                    href={`/user/${item.userName}/characters`}
-                    className="flex justify-between items-center w-full h-full px-4 py-3"
+          return (
+            <li
+              key={item.userId}
+              className={`group rounded-md border border-gray-800 hover:border-gray-700 hover:bg-gray-800/40 transition-colors duration-150 relative overflow-hidden ${supporterRowClass(item.supporterTier)}`}
+            >
+              <LinkComponent
+                href={`/user/${item.userName}/characters`}
+                className="flex justify-between items-center w-full h-full px-4 py-3"
+              >
+                <div className="flex items-center space-x-3">
+                  <div
+                    className={`flex items-center justify-center w-7 h-7 rounded-md text-xs font-semibold tabular-nums ${rankBadge}`}
                   >
-                    <div className="flex items-center space-x-3">
-                      <div
-                        className={`flex items-center justify-center w-7 h-7 rounded-md text-xs font-semibold tabular-nums ${rankBadge}`}
-                      >
-                        {globalRank}
-                      </div>
-                      <span
-                        className="text-sm font-medium text-gray-200 group-hover:text-indigo-400 transition-colors duration-150 inline-flex items-center gap-1"
-                        style={supporterNameStyle(item.supporterTier)}
-                      >
-                        {item.userName}
-                        {item.supporterTier > 0 && (
-                          <SupporterBadge tier={item.supporterTier} />
-                        )}
-                      </span>
-                    </div>
-                    <span className="text-sm font-semibold text-gray-300 tabular-nums">
-                      {formatNumber(value)}
-                    </span>
-                  </LinkComponent>
-                </li>
-              );
-            })}
-          </ol>
+                    {globalRank}
+                  </div>
+                  <span
+                    className="text-sm font-medium text-gray-200 group-hover:text-indigo-400 transition-colors duration-150 inline-flex items-center gap-1"
+                    style={supporterNameStyle(item.supporterTier)}
+                  >
+                    {item.userName}
+                    {item.supporterTier > 0 && (
+                      <SupporterBadge tier={item.supporterTier} />
+                    )}
+                  </span>
+                </div>
+                <span className="text-sm font-semibold text-gray-300 tabular-nums">
+                  {formatNumber(value)}
+                </span>
+              </LinkComponent>
+            </li>
+          );
+        })}
+      </ol>
 
-          <div className="my-8 flex justify-center">
-            <Pagination
-              total={totalPages}
-              page={currentPage}
-              onChange={handlePageChange}
-            />
-          </div>
-        </>
-      )}
+      <div className="my-8 flex justify-center">
+        <Pagination
+          total={totalPages}
+          page={currentPage}
+          onChange={handlePageChange}
+        />
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
### Changes
- Enables weekly kills for leaderboard sorting and display.
- Adds kills to RecentActivity for this week and last week.
- Keeps kill deltas aligned with the existing baseline logic.