### PR TITLE
Fix total kill baseline mapping

### DIFF
--- a/src/server/api/myCharactersAddRouteHandlers.ts
+++ b/src/server/api/myCharactersAddRouteHandlers.ts
@@ -40,6 +40,7 @@ export function mapCharacterData(char: any) {
     heraldTotalSoloKills:
       char.realm_war_stats.current.player_kills.total.solo_kills,
     totalRealmPoints: char.realm_war_stats.current.realm_points,
+    totalKills: char.realm_war_stats.current.player_kills.total.kills,
     totalSoloKills: char.realm_war_stats.current.player_kills.total.solo_kills,
     totalDeaths: char.realm_war_stats.current.player_kills.total.deaths,
     totalDeathBlows: char.realm_war_stats.current.player_kills.total.death_blows,

--- a/tests/my-characters.crud.test.ts
+++ b/tests/my-characters.crud.test.ts
@@ -176,11 +176,11 @@ test("add handler returns 500 when upstream fetch fails", async () => {
 test("mapCharacterData keeps total kill baseline in sync", () => {
   const payload = mapCharacterData({
     character_web_id: "w1",
-    name: "Dwaloha",
-    class_name: "Warlock",
+    name: "Baseline Test",
+    class_name: "Healer",
     realm: 2,
     server_name: "Ywain",
-    race: "Frostalf",
+    race: "Norseman",
     level: 50,
     guild_info: { guild_name: "Guild" },
     realm_war_stats: {

--- a/tests/my-characters.crud.test.ts
+++ b/tests/my-characters.crud.test.ts
@@ -1,6 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { createMyCharactersAddRouteHandlers } from "../src/server/api/myCharactersAddRouteHandlers";
+import {
+  createMyCharactersAddRouteHandlers,
+  mapCharacterData,
+} from "../src/server/api/myCharactersAddRouteHandlers";
 import { createUserCharactersByUserIdHandler } from "../src/server/userCharactersByUserIdPagesHandler";
 import { createUserCharacterHandler } from "../src/server/userCharacterPagesHandler";
 
@@ -168,6 +171,41 @@ test("add handler returns 500 when upstream fetch fails", async () => {
     String((await response.json() as { details: string }).details),
     /upstream boom/i
   );
+});
+
+test("mapCharacterData keeps total kill baseline in sync", () => {
+  const payload = mapCharacterData({
+    character_web_id: "w1",
+    name: "Dwaloha",
+    class_name: "Warlock",
+    realm: 2,
+    server_name: "Ywain",
+    race: "Frostalf",
+    level: 50,
+    guild_info: { guild_name: "Guild" },
+    realm_war_stats: {
+      current: {
+        realm_points: 5_632_599,
+        bounty_points: 100,
+        player_kills: {
+          total: {
+            kills: 47_054,
+            deaths: 1_001,
+            death_blows: 8_468,
+            solo_kills: 123,
+          },
+        },
+      },
+    },
+    master_level: { level: 10 },
+  });
+
+  assert.equal(payload.heraldTotalKills, 47_054);
+  assert.equal(payload.totalKills, 47_054);
+  assert.equal(payload.totalRealmPoints, 5_632_599);
+  assert.equal(payload.totalDeathBlows, 8_468);
+  assert.equal(payload.totalSoloKills, 123);
+  assert.equal(payload.totalDeaths, 1_001);
 });
 
 test("userCharactersByUserId handler returns 400 for invalid userId", async () => {


### PR DESCRIPTION
### Changes
- Maps totalKills when characters are added or refreshed.
- Keeps kill baselines aligned with RP, deathblows, solo kills, and deaths.
- Adds regression coverage for the kill baseline mapping.