### PR TITLE
Harden weekly kill baseline handling

### DIFF
--- a/src/server/api/batchedLeaderboardUpdateRouteHandlers.ts
+++ b/src/server/api/batchedLeaderboardUpdateRouteHandlers.ts
@@ -45,24 +45,106 @@ type BatchedLeaderboardUpdateDeps = {
   now: () => Date;
 };
 
-function calculateUpdateTimes(
-  now: Date,
-  updateHourUTC: number,
-  gracePeriodHours: number
+const weeklyLeaderboardTimeZone = "America/New_York";
+
+function getTimeZoneParts(date: Date, timeZone: string) {
+  const formatter = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    weekday: "short",
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23",
+  });
+  const parts = formatter.formatToParts(date);
+  const getPart = (type: string) =>
+    parts.find((part) => part.type === type)?.value ?? "0";
+  const weekdayMap: Record<string, number> = {
+    Sun: 0,
+    Mon: 1,
+    Tue: 2,
+    Wed: 3,
+    Thu: 4,
+    Fri: 5,
+    Sat: 6,
+  };
+
+  return {
+    weekday: weekdayMap[getPart("weekday")] ?? 0,
+    year: Number(getPart("year")),
+    month: Number(getPart("month")),
+    day: Number(getPart("day")),
+    hour: Number(getPart("hour")),
+    minute: Number(getPart("minute")),
+    second: Number(getPart("second")),
+  };
+}
+
+function getTimeZoneOffsetMs(date: Date, timeZone: string) {
+  const parts = getTimeZoneParts(date, timeZone);
+  const asUtc = Date.UTC(
+    parts.year,
+    parts.month - 1,
+    parts.day,
+    parts.hour,
+    parts.minute,
+    parts.second
+  );
+  return asUtc - date.getTime();
+}
+
+function getUtcForTimeZoneDate(
+  parts: {
+    year: number;
+    month: number;
+    day: number;
+    hour: number;
+    minute: number;
+    second: number;
+  },
+  timeZone: string
 ) {
-  const mondayAtUpdateHour = new Date(now);
-  mondayAtUpdateHour.setUTCHours(updateHourUTC, 0, 0, 0);
-  mondayAtUpdateHour.setUTCDate(
-    mondayAtUpdateHour.getUTCDate() - ((mondayAtUpdateHour.getUTCDay() + 6) % 7)
+  const utcGuess = new Date(
+    Date.UTC(
+      parts.year,
+      parts.month - 1,
+      parts.day,
+      parts.hour,
+      parts.minute,
+      parts.second
+    )
+  );
+  const offset = getTimeZoneOffsetMs(utcGuess, timeZone);
+  const utcDate = new Date(utcGuess.getTime() - offset);
+  const adjustedOffset = getTimeZoneOffsetMs(utcDate, timeZone);
+  return adjustedOffset === offset
+    ? utcDate
+    : new Date(utcGuess.getTime() - adjustedOffset);
+}
+
+function calculateUpdateTimes(now: Date, gracePeriodHours: number) {
+  const nowParts = getTimeZoneParts(now, weeklyLeaderboardTimeZone);
+  const daysSinceMonday = (nowParts.weekday + 6) % 7;
+  const mondayDate = new Date(
+    Date.UTC(nowParts.year, nowParts.month - 1, nowParts.day - daysSinceMonday)
+  );
+  const mondayStart = getUtcForTimeZoneDate(
+    {
+      year: mondayDate.getUTCFullYear(),
+      month: mondayDate.getUTCMonth() + 1,
+      day: mondayDate.getUTCDate(),
+      hour: 0,
+      minute: 0,
+      second: 0,
+    },
+    weeklyLeaderboardTimeZone
   );
 
-  const lastMonday = new Date(mondayAtUpdateHour.getTime());
-  if (now.getTime() < mondayAtUpdateHour.getTime()) {
-    lastMonday.setUTCDate(lastMonday.getUTCDate() - 7);
-  }
-
   const gracePeriodEndTime = new Date(
-    lastMonday.getTime() + gracePeriodHours * 60 * 60 * 1000
+    mondayStart.getTime() + gracePeriodHours * 60 * 60 * 1000
   );
   return { gracePeriodEndTime };
 }
@@ -96,11 +178,9 @@ export function createBatchedLeaderboardUpdateRouteHandlers(
       let failedCount = 0;
 
       const gracePeriodHours = 0.5;
-      const updateHourUTC = 5;
 
       const { gracePeriodEndTime } = calculateUpdateTimes(
         deps.now(),
-        updateHourUTC,
         gracePeriodHours
       );
       const cursorKey = getWeeklyLeaderboardCursorKey(gracePeriodEndTime);
@@ -137,10 +217,15 @@ export function createBatchedLeaderboardUpdateRouteHandlers(
             const currentStats = data.realm_war_stats.current;
             if (character.lastUpdated) {
               const characterLastUpdated = new Date(character.lastUpdated);
+              const currentTotalKills = currentStats.player_kills.total.kills;
+              const storedTotalKills = character.totalKills ?? 0;
+              const hasMissingKillBaseline =
+                storedTotalKills === 0 && currentTotalKills > 0;
               const realmPointsDiff =
                 currentStats.realm_points - character.totalRealmPoints;
-              const killsDiff =
-                currentStats.player_kills.total.kills - (character.totalKills ?? 0);
+              const killsDiff = hasMissingKillBaseline
+                ? 0
+                : currentTotalKills - storedTotalKills;
               const soloKillsDiff =
                 currentStats.player_kills.total.solo_kills - character.totalSoloKills;
               const deathsDiff =
@@ -155,10 +240,8 @@ export function createBatchedLeaderboardUpdateRouteHandlers(
               if (character.totalRealmPoints !== currentStats.realm_points) {
                 updateData.totalRealmPoints = currentStats.realm_points;
               }
-              if (
-                (character.totalKills ?? 0) !== currentStats.player_kills.total.kills
-              ) {
-                updateData.totalKills = currentStats.player_kills.total.kills;
+              if (storedTotalKills !== currentTotalKills) {
+                updateData.totalKills = currentTotalKills;
               }
               if (
                 character.totalSoloKills !== currentStats.player_kills.total.solo_kills
@@ -193,7 +276,10 @@ export function createBatchedLeaderboardUpdateRouteHandlers(
               if (character.realmPointsLastWeek !== weeklyRealmPoints) {
                 updateData.realmPointsLastWeek = weeklyRealmPoints;
               }
-              if ((character.killsLastWeek ?? 0) !== weeklyKills) {
+              if (
+                (character.killsLastWeek ?? 0) !== weeklyKills ||
+                hasMissingKillBaseline
+              ) {
                 updateData.killsLastWeek = weeklyKills;
               }
               if (character.soloKillsLastWeek !== weeklySoloKills) {

--- a/src/server/leaderboard.ts
+++ b/src/server/leaderboard.ts
@@ -136,8 +136,14 @@ export const aggregateLeaderboardData = (
         character.heraldTotalKills !== null &&
         character.totalKills !== null
       ) {
-        accumulatedKillsThisWeek +=
-          character.heraldTotalKills - character.totalKills;
+        const hasMissingKillBaseline =
+          character.totalKills === 0 &&
+          character.heraldTotalKills > 0 &&
+          character.killsLastWeek === 0;
+        if (!hasMissingKillBaseline) {
+          accumulatedKillsThisWeek +=
+            character.heraldTotalKills - character.totalKills;
+        }
       }
       if (
         character.heraldTotalDeaths !== null &&

--- a/tests/cron.routes.migration.test.ts
+++ b/tests/cron.routes.migration.test.ts
@@ -310,6 +310,22 @@ test("batched leaderboard preserves cursor update and success payload", async ()
   assert.equal(readCursorKey, "lastProcessedCharacterId:weekly:2026-04-06");
   assert.equal(updatedCursorKey, "lastProcessedCharacterId:weekly:2026-04-06");
   assert.equal(updatedRows.length, 1);
+  assert.deepEqual(updatedRows[0], {
+    id: 10,
+    data: {
+      totalRealmPoints: 15,
+      realmPointsLastWeek: 5,
+      totalKills: 16,
+      killsLastWeek: 5,
+      totalSoloKills: 12,
+      soloKillsLastWeek: 2,
+      totalDeaths: 11,
+      deathsLastWeek: 1,
+      totalDeathBlows: 14,
+      deathBlowsLastWeek: 4,
+      lastUpdated: new Date("2026-04-06T05:10:00.000Z"),
+    },
+  });
   assert.deepEqual(await response.json(), {
     message: "Batch update process completed",
     checkedCharacters: 1,
@@ -318,11 +334,76 @@ test("batched leaderboard preserves cursor update and success payload", async ()
   });
 });
 
-test("batched leaderboard uses previous Monday window before update hour", async () => {
-  let capturedCutoffIso: string | null = null;
+test("batched leaderboard repairs missing kill baseline without weekly kill credit", async () => {
+  const updatedRows: Array<{ id: number; data: Record<string, unknown> }> = [];
   const handlers = createBatchedLeaderboardUpdateRouteHandlers({
     cronSecret: "secret",
     getLastProcessedCharacterId: async () => 0,
+    updateLastProcessedCharacterId: async () => undefined,
+    findCharacters: async () => [
+      {
+        id: 11,
+        webId: "w11",
+        totalRealmPoints: 1000,
+        totalKills: 0,
+        totalSoloKills: 10,
+        totalDeaths: 5,
+        totalDeathBlows: 20,
+        realmPointsLastWeek: 0,
+        killsLastWeek: 0,
+        soloKillsLastWeek: 0,
+        deathsLastWeek: 0,
+        deathBlowsLastWeek: 0,
+        lastUpdated: new Date("2026-03-30T05:00:00.000Z"),
+      },
+    ],
+    updateCharacter: async ({ id, data }) => {
+      updatedRows.push({ id, data: data as unknown as Record<string, unknown> });
+    },
+    fetchImpl: (async () =>
+      new Response(
+        JSON.stringify({
+          realm_war_stats: {
+            current: {
+              realm_points: 1500,
+              player_kills: {
+                total: {
+                  kills: 259,
+                  solo_kills: 12,
+                  deaths: 6,
+                  death_blows: 25,
+                },
+              },
+            },
+          },
+        })
+      )) as typeof fetch,
+    now: () => new Date("2026-04-06T05:10:00.000Z"),
+  });
+
+  const response = await handlers.POST(
+    authorizedRequest("http://localhost/api/batchedLeaderboardUpdate", "POST")
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(updatedRows.length, 1);
+  assert.equal(updatedRows[0].data.totalKills, 259);
+  assert.equal(updatedRows[0].data.killsLastWeek, 0);
+  assert.equal(updatedRows[0].data.realmPointsLastWeek, 500);
+  assert.equal(updatedRows[0].data.deathBlowsLastWeek, 5);
+  assert.equal(updatedRows[0].data.soloKillsLastWeek, 2);
+  assert.equal(updatedRows[0].data.deathsLastWeek, 1);
+});
+
+test("batched leaderboard uses Monday midnight ET cutoff during daylight time", async () => {
+  let capturedCutoffIso: string | null = null;
+  let readCursorKey = "";
+  const handlers = createBatchedLeaderboardUpdateRouteHandlers({
+    cronSecret: "secret",
+    getLastProcessedCharacterId: async (key) => {
+      readCursorKey = key ?? "";
+      return 0;
+    },
     updateLastProcessedCharacterId: async () => undefined,
     findCharacters: async ({ lastUpdatedLte }) => {
       capturedCutoffIso = lastUpdatedLte.toISOString();
@@ -338,13 +419,42 @@ test("batched leaderboard uses previous Monday window before update hour", async
   );
 
   assert.equal(response.status, 200);
-  assert.equal(capturedCutoffIso, "2026-03-30T05:30:00.000Z");
+  assert.equal(capturedCutoffIso, "2026-04-06T04:30:00.000Z");
+  assert.equal(readCursorKey, "lastProcessedCharacterId:weekly:2026-04-06");
   assert.deepEqual(await response.json(), {
     message: "Batch update process completed",
     checkedCharacters: 0,
     updatedCharacters: 0,
     failedUpdates: 0,
   });
+});
+
+test("batched leaderboard uses Monday midnight ET cutoff during standard time", async () => {
+  let capturedCutoffIso: string | null = null;
+  let readCursorKey = "";
+  const handlers = createBatchedLeaderboardUpdateRouteHandlers({
+    cronSecret: "secret",
+    getLastProcessedCharacterId: async (key) => {
+      readCursorKey = key ?? "";
+      return 0;
+    },
+    updateLastProcessedCharacterId: async () => undefined,
+    findCharacters: async ({ lastUpdatedLte }) => {
+      capturedCutoffIso = lastUpdatedLte.toISOString();
+      return [];
+    },
+    updateCharacter: async () => undefined,
+    fetchImpl: (async () => new Response("{}")) as typeof fetch,
+    now: () => new Date("2026-01-05T05:35:00.000Z"),
+  });
+
+  const response = await handlers.POST(
+    authorizedRequest("http://localhost/api/batchedLeaderboardUpdate", "POST")
+  );
+
+  assert.equal(response.status, 200);
+  assert.equal(capturedCutoffIso, "2026-01-05T05:30:00.000Z");
+  assert.equal(readCursorKey, "lastProcessedCharacterId:weekly:2026-01-05");
 });
 
 test("batched leaderboard returns 500 on initialization failure", async () => {

--- a/tests/leaderboard.aggregate.test.ts
+++ b/tests/leaderboard.aggregate.test.ts
@@ -140,6 +140,47 @@ test("aggregateLeaderboardData deduplicates repeated character ids and clamps we
   assert.equal(result[0].deathBlowsThisWeek, 0);
 });
 
+test("aggregateLeaderboardData ignores missing kill baseline for this week", () => {
+  const data = [
+    {
+      id: 1,
+      name: "Alice",
+      clerkUserId: "u_1",
+      characters: [
+        {
+          character: {
+            id: 101,
+            totalRealmPoints: 1000,
+            totalKills: 0,
+            totalSoloKills: 10,
+            totalDeaths: 5,
+            totalDeathBlows: 20,
+            killsLastWeek: 0,
+            deathsLastWeek: 0,
+            deathBlowsLastWeek: 0,
+            realmPointsLastWeek: 0,
+            soloKillsLastWeek: 0,
+            lastUpdated: null,
+            heraldRealmPoints: 1200,
+            heraldTotalKills: 259,
+            heraldTotalDeaths: 6,
+            heraldTotalSoloKills: 12,
+            heraldTotalDeathBlows: 25,
+          },
+        },
+      ],
+    },
+  ];
+
+  const result = aggregateLeaderboardData(data);
+
+  assert.equal(result[0].killsThisWeek, 0);
+  assert.equal(result[0].realmPointsThisWeek, 200);
+  assert.equal(result[0].deathBlowsThisWeek, 5);
+  assert.equal(result[0].soloKillsThisWeek, 2);
+  assert.equal(result[0].deathsThisWeek, 1);
+});
+
 test("aggregateLeaderboardData uses effective death blow baseline for weekly guard", () => {
   const leaderboardSource = readFileSync("src/server/leaderboard.ts", "utf8");
 


### PR DESCRIPTION
### Changes
- Prevents missing kill baselines from counting lifetime kills as weekly or this-week kills.
- Uses Monday midnight ET plus grace for weekly batch cutoff, including DST.
- Adds regression coverage for missing kill baselines and ET cutoff behavior.