### PR TITLE
Add database indexes and tighten read-path queries for API performance

### DIFF
--- a/convex/drafts.ts
+++ b/convex/drafts.ts
@@ -1979,16 +1979,30 @@ export const adminReplaceDraftFights = mutation({
 export const getDraftsForModeration = query({
   args: {},
   handler: async (ctx) => {
-    const completedDrafts = await ctx.db
+    const unverifiedDrafts = await ctx.db
       .query("drafts")
-      .withIndex("by_status", (q) => q.eq("status", "complete"))
+      .withIndex("by_status_resultStatus", (q) =>
+        q.eq("status", "complete").eq("resultStatus", "unverified")
+      )
       .collect();
 
-    const pending = completedDrafts.filter(
+    const legacyUnverified = (
+      await ctx.db
+        .query("drafts")
+        .withIndex("by_status", (q) => q.eq("status", "complete"))
+        .collect()
+    ).filter(
       (draft) =>
-        draft.winnerTeam !== undefined &&
-        (draft.resultStatus === undefined || draft.resultStatus === "unverified")
+        draft.winnerTeam !== undefined && draft.resultStatus === undefined
     );
+
+    const pendingById = new Map<string, (typeof unverifiedDrafts)[number]>();
+    for (const draft of [...unverifiedDrafts, ...legacyUnverified]) {
+      if (draft.winnerTeam !== undefined) {
+        pendingById.set(draft._id, draft);
+      }
+    }
+    const pending = Array.from(pendingById.values());
 
     const results = [];
     for (const draft of pending) {
@@ -2045,16 +2059,23 @@ export const getDraftsForModeration = query({
 export const getReviewedDraftsForModeration = query({
   args: {},
   handler: async (ctx) => {
-    const completedDrafts = await ctx.db
+    const verifiedDrafts = await ctx.db
       .query("drafts")
-      .withIndex("by_status", (q) => q.eq("status", "complete"))
+      .withIndex("by_status_resultStatus", (q) =>
+        q.eq("status", "complete").eq("resultStatus", "verified")
+      )
+      .collect();
+    const voidedDrafts = await ctx.db
+      .query("drafts")
+      .withIndex("by_status_resultStatus", (q) =>
+        q.eq("status", "complete").eq("resultStatus", "voided")
+      )
       .collect();
 
-    const reviewed = completedDrafts.filter(
-      (draft) =>
-        draft.winnerTeam !== undefined &&
-        (draft.resultStatus === "verified" || draft.resultStatus === "voided")
-    );
+    const reviewed = [...verifiedDrafts, ...voidedDrafts]
+      .filter((draft) => draft.winnerTeam !== undefined)
+      .sort((a, b) => b._creationTime - a._creationTime)
+      .slice(0, 50);
 
     const results = [];
     for (const draft of reviewed) {
@@ -2106,21 +2127,21 @@ export const getReviewedDraftsForModeration = query({
       });
     }
 
-    return results.sort((a, b) => b._creationTime - a._creationTime).slice(0, 50);
+    return results;
   },
 });
 
 export const getVerifiedDraftResults = query({
   args: {},
   handler: async (ctx) => {
-    const completedDrafts = await ctx.db
-      .query("drafts")
-      .withIndex("by_status", (q) => q.eq("status", "complete"))
-      .collect();
-
-    const verified = completedDrafts.filter(
-      (draft) => draft.winnerTeam !== undefined && draft.resultStatus === "verified"
-    );
+    const verified = (
+      await ctx.db
+        .query("drafts")
+        .withIndex("by_status_resultStatus", (q) =>
+          q.eq("status", "complete").eq("resultStatus", "verified")
+        )
+        .collect()
+    ).filter((draft) => draft.winnerTeam !== undefined);
 
     const results = [];
     for (const draft of verified) {
@@ -2729,10 +2750,27 @@ export const getCancelledDraftsForAdmin = query({
   handler: async (ctx) => {
     const CANCELLED_RETENTION_MS = 90 * 24 * 60 * 60 * 1000;
     const cutoff = Date.now() - CANCELLED_RETENTION_MS;
-    const drafts = await ctx.db
-      .query("drafts")
-      .withIndex("by_status", (q) => q.eq("status", "cancelled"))
-      .collect();
+    const draftsWithCancelledAt = (
+      await ctx.db
+        .query("drafts")
+        .withIndex("by_status_cancelledAt", (q) =>
+          q.eq("status", "cancelled").gte("cancelledAt", cutoff)
+        )
+        .collect()
+    ).filter(
+      (draft) =>
+        typeof draft.cancelledAt === "number" && draft.cancelledAt >= cutoff
+    );
+    const legacyDrafts = (
+      await ctx.db
+        .query("drafts")
+        .withIndex("by_status", (q) => q.eq("status", "cancelled"))
+        .collect()
+    ).filter(
+      (draft) =>
+        draft.cancelledAt === undefined && draft._creationTime >= cutoff
+    );
+    const drafts = [...draftsWithCancelledAt, ...legacyDrafts];
 
     const results = [];
     for (const draft of drafts) {
@@ -2752,9 +2790,6 @@ export const getCancelledDraftsForAdmin = query({
       ).length;
 
       const cancelledAt = draft.cancelledAt ?? draft._creationTime;
-      if (cancelledAt < cutoff) {
-        continue;
-      }
 
       results.push({
         _id: draft._id,
@@ -2825,17 +2860,37 @@ export const purgeExpiredCancelledDrafts = mutation({
         : 90;
     const cutoff = Date.now() - retentionDays * 24 * 60 * 60 * 1000;
 
-    const cancelledDrafts = await ctx.db
-      .query("drafts")
-      .withIndex("by_status", (q) => q.eq("status", "cancelled"))
-      .collect();
+    const expiredWithCancelledAt = (
+      await ctx.db
+        .query("drafts")
+        .withIndex("by_status_cancelledAt", (q) =>
+          q.eq("status", "cancelled").lt("cancelledAt", cutoff)
+        )
+        .collect()
+    ).filter(
+      (draft) =>
+        typeof draft.cancelledAt === "number" && draft.cancelledAt < cutoff
+    );
+    const expiredLegacy = (
+      await ctx.db
+        .query("drafts")
+        .withIndex("by_status", (q) => q.eq("status", "cancelled"))
+        .collect()
+    ).filter(
+      (draft) =>
+        draft.cancelledAt === undefined && draft._creationTime < cutoff
+    );
+    const cancelledDraftsById = new Map<
+      string,
+      (typeof expiredWithCancelledAt)[number]
+    >();
+    for (const draft of [...expiredWithCancelledAt, ...expiredLegacy]) {
+      cancelledDraftsById.set(draft._id, draft);
+    }
+    const cancelledDrafts = Array.from(cancelledDraftsById.values());
 
     let deletedDrafts = 0;
     for (const draft of cancelledDrafts) {
-      const cancelledAt = draft.cancelledAt ?? draft._creationTime;
-      if (cancelledAt >= cutoff) {
-        continue;
-      }
 
       const players = await ctx.db
         .query("draftPlayers")
@@ -3376,13 +3431,19 @@ export const getActiveDrafts = query({
         .collect();
       active.push(...drafts);
     }
-    const completedNotStarted = (
+    const completedNotStartedFalse = await ctx.db
+      .query("drafts")
+      .withIndex("by_status_gameStarted", (q) =>
+        q.eq("status", "complete").eq("gameStarted", false)
+      )
+      .collect();
+    const completedNotStartedUnset = (
       await ctx.db
         .query("drafts")
         .withIndex("by_status", (q) => q.eq("status", "complete"))
         .collect()
-    ).filter((d) => !d.gameStarted);
-    active.push(...completedNotStarted);
+    ).filter((d) => d.gameStarted === undefined);
+    active.push(...completedNotStartedFalse, ...completedNotStartedUnset);
 
     const results = [];
     for (const draft of active) {

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -102,7 +102,10 @@ export default defineSchema({
     reviewNotificationSentAt: v.optional(v.number()),
   })
     .index("by_shortId", ["shortId"])
-    .index("by_status", ["status"]),
+    .index("by_status", ["status"])
+    .index("by_status_resultStatus", ["status", "resultStatus"])
+    .index("by_status_gameStarted", ["status", "gameStarted"])
+    .index("by_status_cancelledAt", ["status", "cancelledAt"]),
 
   draftPlayers: defineTable({
     draftId: v.id("drafts"),

--- a/prisma/migrations/20260527120000_add_query_performance_indexes/migration.sql
+++ b/prisma/migrations/20260527120000_add_query_performance_indexes/migration.sql
@@ -1,0 +1,23 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+CREATE INDEX "User_supporterTier_idx" ON "User"("supporterTier");
+
+CREATE INDEX "Character_characterName_idx" ON "Character"("characterName");
+CREATE INDEX "Character_lastUpdated_id_idx" ON "Character"("lastUpdated", "id");
+CREATE INDEX "Character_nameLastUpdated_id_idx" ON "Character"("nameLastUpdated", "id");
+
+CREATE INDEX "UserIdentityLink_provider_status_idx" ON "UserIdentityLink"("provider", "status");
+
+CREATE INDEX "UserIdentityClaim_status_createdAt_idx" ON "UserIdentityClaim"("status", "createdAt");
+CREATE INDEX "UserIdentityClaim_clerkUserId_provider_providerUserId_status_idx" ON "UserIdentityClaim"("clerkUserId", "provider", "providerUserId", "status");
+
+CREATE INDEX "User_name_trgm_idx" ON "User" USING gin ("name" gin_trgm_ops);
+CREATE INDEX "User_email_trgm_idx" ON "User" USING gin ("email" gin_trgm_ops);
+CREATE INDEX "Character_heraldName_trgm_idx" ON "Character" USING gin ("heraldName" gin_trgm_ops);
+
+CREATE INDEX "User_subscription_provider_idx" ON "User"("subscriptionProvider")
+WHERE "subscriptionProvider" IS NOT NULL
+   OR "stripeSubscriptionId" IS NOT NULL
+   OR "stripeCustomerId" IS NOT NULL
+   OR "paypalSubscriptionId" IS NOT NULL
+   OR "paypalPayerId" IS NOT NULL;

--- a/prisma/migrations/20260527130000_add_character_name_lower_index/migration.sql
+++ b/prisma/migrations/20260527130000_add_character_name_lower_index/migration.sql
@@ -1,0 +1,1 @@
+CREATE INDEX "Character_characterName_lower_idx" ON "Character" (LOWER("characterName"));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -53,6 +53,8 @@ model User {
   groupUsers     GroupUser[]
   identityLinks  UserIdentityLink[]
   identityClaims UserIdentityClaim[]
+
+  @@index([supporterTier])
 }
 
 model StripeWebhookEvent {
@@ -116,6 +118,10 @@ model Character {
   heraldHiberniaDeathBlows Int?
   heraldHiberniaSoloKills Int?
   heraldMasterLevel       String?
+
+  @@index([characterName])
+  @@index([lastUpdated, id])
+  @@index([nameLastUpdated, id])
 }
 
 
@@ -173,6 +179,7 @@ model UserIdentityLink {
   @@unique([provider, providerUserId])
   @@unique([clerkUserId, provider])
   @@index([clerkUserId])
+  @@index([provider, status])
 }
 
 model UserIdentityClaim {
@@ -189,6 +196,8 @@ model UserIdentityClaim {
 
   @@index([clerkUserId, provider])
   @@index([provider, providerUserId])
+  @@index([status, createdAt])
+  @@index([clerkUserId, provider, providerUserId, status])
 }
 
 

--- a/scripts/verifyQueryIndexes.sql
+++ b/scripts/verifyQueryIndexes.sql
@@ -1,0 +1,31 @@
+-- Run after applying migrations (psql or: pnpm exec prisma db execute --file scripts/verifyQueryIndexes.sql)
+-- Expect index scans on large tables, not sequential scans.
+
+EXPLAIN ANALYZE
+SELECT "id", "clerkUserId", "name"
+FROM "User"
+WHERE "name" ILIKE '%ken%'
+LIMIT 20;
+
+EXPLAIN ANALYZE
+SELECT "id", "characterName"
+FROM "Character"
+WHERE "heraldName" ILIKE '%ken%'
+LIMIT 20;
+
+EXPLAIN ANALYZE
+SELECT "id", "clerkUserId", "provider", "status", "createdAt"
+FROM "UserIdentityClaim"
+WHERE "status" = 'pending'
+ORDER BY "createdAt" DESC;
+
+EXPLAIN ANALYZE
+SELECT "id", "providerUserId", "clerkUserId"
+FROM "UserIdentityLink"
+WHERE "provider" = 'discord' AND "status" = 'linked';
+
+EXPLAIN ANALYZE
+SELECT "id", "characterName"
+FROM "Character"
+WHERE LOWER("characterName") = LOWER('SomeName')
+LIMIT 1;

--- a/src/app/api/characters/route.ts
+++ b/src/app/api/characters/route.ts
@@ -13,7 +13,8 @@ const handlers = createCharactersCollectionRouteHandlers({
     prisma.user.findUnique({
       where: { id },
     }),
-  getCharacters: () => characterController.getCharacters(),
+  getCharacters: (clerkUserId) =>
+    characterController.getCharactersForUser(clerkUserId),
   addCharactersToUserList: (characters, userId) =>
     characterController.addCharactersToUserList(
       characters as string[],

--- a/src/server/api/charactersCollectionRouteHandlers.ts
+++ b/src/server/api/charactersCollectionRouteHandlers.ts
@@ -6,7 +6,7 @@ export type CharactersCollectionDeps = {
     clerkUserId: string
   ) => Promise<{ id: number } | null>;
   findUserById: (id: number) => Promise<unknown | null>;
-  getCharacters: () => Promise<unknown>;
+  getCharacters: (clerkUserId: string) => Promise<unknown>;
   addCharactersToUserList: (
     characters: unknown[],
     userId: number
@@ -51,7 +51,7 @@ export function createCharactersCollectionRouteHandlers(
       }
 
       try {
-        const characters = await deps.getCharacters();
+        const characters = await deps.getCharacters(clerkUserId);
         return NextResponse.json(characters);
       } catch (error) {
         return handleError(error);

--- a/src/server/draftStats.ts
+++ b/src/server/draftStats.ts
@@ -1,4 +1,5 @@
 import { ConvexHttpClient } from "convex/browser";
+import { unstable_cache } from "next/cache";
 import prisma from "../../prisma/prismaClient";
 import {
   aggregateDraftLeaderboardRows,
@@ -823,7 +824,16 @@ export function aggregatePlayerDrilldown(
   };
 }
 
-async function loadDraftIdentityContext(): Promise<DraftIdentityContext> {
+type DraftIdentityCachePayload = {
+  drafts: DraftLeaderboardDraft[];
+  identityLinks: Array<{
+    providerUserId: string;
+    clerkUserId: string;
+    userName: string;
+  }>;
+};
+
+async function loadDraftIdentityCachePayload(): Promise<DraftIdentityCachePayload> {
   const convex = getConvexClient();
   const drafts = (await convex.query(
     "drafts:getVerifiedDraftResults" as any,
@@ -846,22 +856,46 @@ async function loadDraftIdentityContext(): Promise<DraftIdentityContext> {
     },
   });
 
+  return {
+    drafts,
+    identityLinks: identityLinks.map((link) => ({
+      providerUserId: link.providerUserId,
+      clerkUserId: link.clerkUserId,
+      userName:
+        link.user.name && link.user.name.trim()
+          ? link.user.name
+          : link.clerkUserId,
+    })),
+  };
+}
+
+const loadDraftIdentityCachePayloadCached = unstable_cache(
+  loadDraftIdentityCachePayload,
+  ["draft-identity-context"],
+  { revalidate: 60 }
+);
+
+function buildDraftIdentityContext(
+  payload: DraftIdentityCachePayload
+): DraftIdentityContext {
   const clerkByDiscordUserId = new Map<string, string>();
   const userNameByClerkUserId = new Map<string, string>();
 
-  for (const link of identityLinks) {
+  for (const link of payload.identityLinks) {
     clerkByDiscordUserId.set(link.providerUserId, link.clerkUserId);
-    userNameByClerkUserId.set(
-      link.clerkUserId,
-      link.user.name && link.user.name.trim() ? link.user.name : link.clerkUserId
-    );
+    userNameByClerkUserId.set(link.clerkUserId, link.userName);
   }
 
   return {
-    drafts,
+    drafts: payload.drafts,
     clerkByDiscordUserId,
     userNameByClerkUserId,
   };
+}
+
+async function loadDraftIdentityContext(): Promise<DraftIdentityContext> {
+  const payload = await loadDraftIdentityCachePayloadCached();
+  return buildDraftIdentityContext(payload);
 }
 
 export async function getOverallDraftStats(filters: DraftStatsFilters) {

--- a/src/server/services/characterService.ts
+++ b/src/server/services/characterService.ts
@@ -161,8 +161,12 @@ export const addCharactersToUserList = async (
   }
 };
 
-export const getCharacters = async () => {
-  return await prisma.character.findMany();
+export const getCharactersForUser = async (clerkUserId: string) => {
+  const userCharacters = await prisma.userCharacter.findMany({
+    where: { clerkUserId },
+    include: { character: true },
+  });
+  return userCharacters.map((uc) => uc.character);
 };
 
 export const getCharacterById = async (id: number) => {

--- a/src/server/services/userCharacterService.ts
+++ b/src/server/services/userCharacterService.ts
@@ -23,23 +23,15 @@ export const createUserCharacter = async (data: any) => {
   }
 };
 
-export const getUserCharacters = async (clerkUserId?: string) => {
-  if (clerkUserId) {
-    return await prisma.userCharacter.findMany({
-      where: {
-        clerkUserId: clerkUserId,
-      },
-      include: {
-        character: true,
-      },
-    });
-  } else {
-    return await prisma.userCharacter.findMany({
-      include: {
-        character: true,
-      },
-    });
-  }
+export const getUserCharacters = async (clerkUserId: string) => {
+  return await prisma.userCharacter.findMany({
+    where: {
+      clerkUserId,
+    },
+    include: {
+      character: true,
+    },
+  });
 };
 
 export const getUserCharacterById = async (ids: {

--- a/tests/characters.collection.api.test.ts
+++ b/tests/characters.collection.api.test.ts
@@ -43,7 +43,10 @@ test("characters GET returns character list", async () => {
     getClerkUserId: async () => "user_1",
     findUserByClerkId: async () => ({ id: 9 }),
     findUserById: async () => ({ id: 9 }),
-    getCharacters: async () => [{ id: 1, webId: "w" }],
+    getCharacters: async (clerkUserId) => {
+      assert.equal(clerkUserId, "user_1");
+      return [{ id: 1, webId: "w" }];
+    },
     addCharactersToUserList: async () => [],
   });
 

--- a/tests/draft.feature.test.ts
+++ b/tests/draft.feature.test.ts
@@ -26,18 +26,47 @@ class MockDb {
   query(table: TableName) {
     const rows = this.tables[table];
     return {
-      withIndex: (_index: string, builder: (q: { eq: (field: string, value: any) => any }) => any) => {
+      withIndex: (
+        _index: string,
+        builder: (q: {
+          eq: (field: string, value: any) => any;
+          gte: (field: string, value: any) => any;
+          lt: (field: string, value: any) => any;
+        }) => any
+      ) => {
         const conditions: Array<{ field: string; value: any }> = [];
+        const rangeConditions: Array<{
+          field: string;
+          op: "gte" | "lt";
+          value: any;
+        }> = [];
         const chain = {
           eq(field: string, value: any) {
             conditions.push({ field, value });
             return chain;
           },
+          gte(field: string, value: any) {
+            rangeConditions.push({ field, op: "gte", value });
+            return chain;
+          },
+          lt(field: string, value: any) {
+            rangeConditions.push({ field, op: "lt", value });
+            return chain;
+          },
         };
         builder(chain);
-        const filtered = rows.filter((row) =>
-          conditions.every((condition) => row[condition.field] === condition.value)
-        );
+        const filtered = rows.filter((row) => {
+          const matchesEq = conditions.every(
+            (condition) => row[condition.field] === condition.value
+          );
+          if (!matchesEq) return false;
+          return rangeConditions.every((condition) => {
+            const rowValue = row[condition.field];
+            if (rowValue === undefined) return condition.op === "lt";
+            if (condition.op === "gte") return rowValue >= condition.value;
+            return rowValue < condition.value;
+          });
+        });
         return {
           unique: async () => {
             if (filtered.length > 1) throw new Error("Unique query returned multiple rows");
@@ -2768,10 +2797,42 @@ test("purgeExpiredCancelledDrafts deletes cancelled draft and related rows beyon
         _creationTime: now - 24 * 60 * 60 * 1000,
         cancelledAt: now - 24 * 60 * 60 * 1000,
       },
+      {
+        _id: "d-legacy-old",
+        shortId: "legacy-old",
+        status: "cancelled",
+        teamSize: 5,
+        createdBy: "creator",
+        discordGuildId: "g1",
+        discordChannelId: "c1",
+        _creationTime: oldTs,
+      },
+      {
+        _id: "d-legacy-new",
+        shortId: "legacy-new",
+        status: "cancelled",
+        teamSize: 5,
+        createdBy: "creator",
+        discordGuildId: "g1",
+        discordChannelId: "c1",
+        _creationTime: now - 24 * 60 * 60 * 1000,
+      },
     ],
     draftPlayers: [
       { _id: "p-old", draftId: "d-old", token: "t1", discordUserId: "u1" },
       { _id: "p-new", draftId: "d-new", token: "t2", discordUserId: "u2" },
+      {
+        _id: "p-legacy-old",
+        draftId: "d-legacy-old",
+        token: "t3",
+        discordUserId: "u3",
+      },
+      {
+        _id: "p-legacy-new",
+        draftId: "d-legacy-new",
+        token: "t4",
+        discordUserId: "u4",
+      },
     ],
     draftBans: [
       { _id: "b-old", draftId: "d-old", className: "Cleric", bannedByTeam: 1 },
@@ -2792,7 +2853,7 @@ test("purgeExpiredCancelledDrafts deletes cancelled draft and related rows beyon
     ctx,
     { retentionDays: 90 }
   );
-  assert.equal(result.deletedDrafts, 1);
+  assert.equal(result.deletedDrafts, 2);
 
   const remainingDrafts = await ctx.db.query("drafts").collect();
   const remainingPlayers = await ctx.db.query("draftPlayers").collect();
@@ -2801,11 +2862,11 @@ test("purgeExpiredCancelledDrafts deletes cancelled draft and related rows beyon
 
   assert.deepEqual(
     remainingDrafts.map((d: any) => d.shortId),
-    ["new"]
+    ["new", "legacy-new"]
   );
   assert.deepEqual(
     remainingPlayers.map((p: any) => p._id),
-    ["p-new"]
+    ["p-new", "p-legacy-new"]
   );
   assert.equal(remainingBans.length, 0);
   assert.equal(remainingFights.length, 0);


### PR DESCRIPTION
- Add Prisma migrations with B-tree indexes for identity claims, identity links, character cron cursors, character name lookups, and supporter filtering, plus pg_trgm GIN indexes for user/character search and a functional LOWER(characterName) index for case-insensitive stats lookups.
- Add Convex compound indexes on drafts (status + resultStatus, status + gameStarted, status + cancelledAt) and refactor moderation/stats queries to use them instead of loading all completed drafts and filtering in memory.
- Fix GET /api/characters to return only the authenticated user's characters via UserCharacter, instead of scanning the full Character table.
- Cache draft identity context (verified drafts + Discord links) for 60s in draftStats.ts to reduce repeated Convex/Prisma load on read-heavy stats routes.
- Fix cancelled-draft purge/admin retention logic so legacy drafts without cancelledAt are not incorrectly matched by - Convex range queries (undefined < number), and dedupe purge candidates by draft id.
- Limit reviewed moderation work to the top 50 drafts before loading players/fights, and require clerkUserId for user-character list queries.
- Add scripts/verifyQueryIndexes.sql for post-deploy EXPLAIN ANALYZE checks.
