### PR TITLE
Improve SEO for DAoC discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 ## divoxutils
 
-`divoxutils` is a web app for the Dark Age of Camelot community focused on character tracking, draft workflows, stats, and moderation tooling.
+`divoxutils` is a web application for the Dark Age of Camelot community. It includes community tools for character tracking, player search, leaderboards, realm ranks, draft history, Discord bot workflows, and Ghost UI.
+
+https://divoxutils.com
 
 ## Features
 
@@ -11,7 +13,7 @@
 - Draft history analytics, class leaderboards, and player drilldowns
 - Discord identity linking and claim/moderation workflows
 - Admin tools for drafts, accounts, identity backfills, and supporter management
-- Supporter billing flows with Stripe
+- Supporter billing flows with Stripe and PayPal
 
 ## Tech Stack
 
@@ -19,5 +21,5 @@
 - Clerk authentication (including Discord sign-in)
 - Convex for real-time draft/data workflows
 - Prisma + PostgreSQL
-- Stripe for billing
+- Stripe and PayPal for billing
 - Vercel deployment

--- a/public/og-divoxutils.svg
+++ b/public/og-divoxutils.svg
@@ -1,0 +1,13 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630" viewBox="0 0 1200 630" role="img" aria-label="divoxutils Dark Age of Camelot tools">
+  <defs>
+    <linearGradient id="bg" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a"/>
+      <stop offset="50%" stop-color="#1e1b4b"/>
+      <stop offset="100%" stop-color="#111827"/>
+    </linearGradient>
+  </defs>
+  <rect width="1200" height="630" fill="url(#bg)"/>
+  <text x="72" y="120" fill="#a5b4fc" font-family="system-ui,sans-serif" font-size="28" letter-spacing="4">DARK AGE OF CAMELOT</text>
+  <text x="72" y="240" font-family="system-ui,sans-serif" font-size="88" font-weight="800"><tspan fill="#818cf8">divox</tspan><tspan fill="#f9fafb">utils</tspan></text>
+  <text x="72" y="320" fill="#d1d5db" font-family="system-ui,sans-serif" font-size="32">Character tracking, leaderboards, drafts, Discord bot</text>
+</svg>

--- a/src/app/_components/HomeCarousel.tsx
+++ b/src/app/_components/HomeCarousel.tsx
@@ -1,134 +1,64 @@
-"use client";
-import React, { useState, useRef, useEffect } from "react";
+import React from "react";
 import { FaTwitch, FaDiscord, FaCoffee } from "react-icons/fa";
-import cn from "classnames";
+import { GiCrossedSwords } from "react-icons/gi";
+import { CarouselItem } from "@/components/ui/carousel";
+import HomeCarouselClient from "./HomeCarouselClient";
+
+const slides = [
+  {
+    text: "Support this project",
+    description: "Help keep divoxutils running",
+    icon: <FaCoffee className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
+    link: "/contribute",
+    openInNewTab: false,
+  },
+  {
+    text: "Follow me on Twitch",
+    description: "Join the community",
+    icon: <FaTwitch className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
+    link: "https://www.twitch.tv/divoxzy",
+    openInNewTab: true,
+  },
+  {
+    text: "Suggestions and feedback",
+    description: "Share your ideas",
+    icon: <FaDiscord className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
+    link: "https://discord.com/users/310750671576236033",
+    openInNewTab: true,
+  },
+  {
+    text: "DAoC community tools",
+    description: "Character tracking, leaderboards, drafts, and more.",
+    icon: <GiCrossedSwords className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
+    link: "/tools",
+    openInNewTab: false,
+  },
+];
 
 export default function HomeCarousel() {
-  const [currentSlide, setCurrentSlide] = useState(0);
-  const [isHovered, setIsHovered] = useState(false);
-  const [hasFocusWithin, setHasFocusWithin] = useState(false);
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
-  const slides = [
-    {
-      text: "Support this project",
-      description: "Help keep divoxutils running",
-      icon: <FaCoffee className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
-      link: "/contribute",
-      openInNewTab: false,
-    },
-    {
-      text: "Follow me on Twitch",
-      description: "Join the community",
-      icon: <FaTwitch className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
-      link: "https://www.twitch.tv/divoxzy",
-      openInNewTab: true,
-    },
-    {
-      text: "Suggestions and feedback",
-      description: "Share your ideas",
-      icon: <FaDiscord className="mx-auto text-indigo-400 h-12 w-12 drop-shadow-lg" />,
-      link: "https://discord.com/users/310750671576236033",
-      openInNewTab: true,
-    },
-  ];
-
-  const carouselRef = useRef<HTMLDivElement | null>(null);
-  const containerRef = useRef<HTMLDivElement | null>(null);
-
-  const goToSlide = (index: number) => {
-    setCurrentSlide(index);
-  };
-
-  useEffect(() => {
-    const mediaQuery = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const syncMotionPreference = () => setPrefersReducedMotion(mediaQuery.matches);
-    syncMotionPreference();
-    mediaQuery.addEventListener("change", syncMotionPreference);
-    return () => mediaQuery.removeEventListener("change", syncMotionPreference);
-  }, []);
-
-  useEffect(() => {
-    if (prefersReducedMotion || isHovered || hasFocusWithin) return;
-    const interval = setInterval(() => {
-      setCurrentSlide((prevSlide) => (prevSlide + 1) % slides.length);
-    }, 5000);
-
-    return () => clearInterval(interval);
-  }, [slides.length, isHovered, hasFocusWithin, prefersReducedMotion]);
-
   return (
-    <div className="relative my-12 mx-auto max-w-2xl">
-      <div
-        ref={containerRef}
-        className="relative bg-gradient-to-br from-gray-900/95 to-gray-800/95 backdrop-blur-sm rounded-2xl overflow-hidden shadow-2xl border border-gray-700/50"
-        onMouseEnter={() => setIsHovered(true)}
-        onMouseLeave={() => setIsHovered(false)}
-        onFocusCapture={() => setHasFocusWithin(true)}
-        onBlurCapture={(event) => {
-          const nextFocused = event.relatedTarget as Node | null;
-          if (nextFocused && containerRef.current?.contains(nextFocused)) return;
-          setHasFocusWithin(false);
-        }}
-      >
-        <div
-          className={cn("flex", {
-            "transition-transform duration-700 ease-out": !prefersReducedMotion,
-          })}
-          style={{ transform: `translateX(-${currentSlide * 100}%)` }}
-          ref={carouselRef}
-        >
-          {slides.map((slide, index) => (
-            <div
-              className="w-full flex-shrink-0"
-              key={index}
-            >
-              <a
-                href={slide.link}
-                target={slide.openInNewTab ? "_blank" : undefined}
-                rel={slide.openInNewTab ? "noopener noreferrer" : undefined}
-                aria-label={`${slide.text}${slide.openInNewTab ? " (opens in a new tab)" : ""}`}
-                className="block p-12 sm:p-16 h-full w-full flex flex-col items-center justify-center text-center group transition-all duration-300 hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40 focus-visible:ring-inset"
-              >
-                <div
-                  className={cn("mb-6", {
-                    "transform transition-transform duration-300 group-hover:scale-110 group-hover:-translate-y-1":
-                      !prefersReducedMotion,
-                  })}
-                  aria-hidden="true"
-                >
-                  {slide.icon}
-                </div>
-                <h3 className="text-xl sm:text-2xl font-bold text-white mb-2 tracking-tight">
-                  {slide.text}
-                </h3>
-                <p className="text-gray-400 text-sm sm:text-base font-medium opacity-90">
-                  {slide.description}
-                </p>
-              </a>
+    <HomeCarouselClient slideCount={slides.length}>
+      {slides.map((slide, index) => (
+        <CarouselItem key={index}>
+          <a
+            href={slide.link}
+            target={slide.openInNewTab ? "_blank" : undefined}
+            rel={slide.openInNewTab ? "noopener noreferrer" : undefined}
+            aria-label={`${slide.text}${slide.openInNewTab ? " (opens in a new tab)" : ""}`}
+            className="block p-12 sm:p-16 h-full w-full flex flex-col items-center justify-center text-center group transition-all duration-300 hover:bg-white/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40 focus-visible:ring-inset"
+          >
+            <div className="mb-6 transform transition-transform duration-300 group-hover:scale-110 group-hover:-translate-y-1" aria-hidden="true">
+              {slide.icon}
             </div>
-          ))}
-        </div>
-
-        <div className="absolute bottom-6 left-1/2 transform -translate-x-1/2">
-          <div className="flex space-x-3">
-            {slides.map((_, index) => (
-              <button
-                key={index}
-                onClick={() => goToSlide(index)}
-                aria-label={`Go to slide ${index + 1}`}
-                aria-current={index === currentSlide ? "true" : undefined}
-                className={cn(
-                  "transition-all duration-300 ease-out rounded-full border-2 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40",
-                  {
-                    "w-8 h-2 bg-indigo-500 border-indigo-500 shadow-lg shadow-indigo-500/25": index === currentSlide,
-                    "w-2 h-2 bg-transparent border-gray-600 hover:border-gray-400": index !== currentSlide,
-                  }
-                )}
-              />
-            ))}
-          </div>
-        </div>
-      </div>
-    </div>
+            <h3 className="text-xl sm:text-2xl font-bold text-white mb-2 tracking-tight">
+              {slide.text}
+            </h3>
+            <p className="text-gray-400 text-sm sm:text-base font-medium opacity-90">
+              {slide.description}
+            </p>
+          </a>
+        </CarouselItem>
+      ))}
+    </HomeCarouselClient>
   );
 }

--- a/src/app/_components/HomeCarouselClient.tsx
+++ b/src/app/_components/HomeCarouselClient.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import React, { useCallback, useEffect, useState, type ReactNode } from "react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+} from "@/components/ui/carousel";
+import { cn } from "@/lib/utils";
+
+type HomeCarouselClientProps = {
+  children: ReactNode;
+  slideCount: number;
+};
+
+export default function HomeCarouselClient({ children, slideCount }: HomeCarouselClientProps) {
+  const [api, setApi] = useState<CarouselApi>();
+  const [currentSlide, setCurrentSlide] = useState(0);
+  const [snapCount, setSnapCount] = useState(slideCount);
+
+  const onSelect = useCallback((api: CarouselApi) => {
+    if (!api) return;
+    setCurrentSlide(api.selectedScrollSnap());
+    setSnapCount(api.scrollSnapList().length);
+  }, []);
+
+  useEffect(() => {
+    if (!api) return;
+    onSelect(api);
+    api.on("select", onSelect);
+    api.on("reInit", onSelect);
+
+    return () => {
+      api.off("select", onSelect);
+      api.off("reInit", onSelect);
+    };
+  }, [api, onSelect]);
+
+  return (
+    <Carousel
+      setApi={setApi}
+      opts={{ align: "start", loop: true }}
+      spacing="none"
+      className="relative my-12 mx-auto max-w-2xl"
+      aria-label="Homepage links"
+    >
+      <div className="rounded-2xl border border-gray-700/50 bg-gradient-to-br from-gray-900/95 to-gray-800/95 shadow-2xl backdrop-blur-sm overflow-hidden">
+        <CarouselContent>{children}</CarouselContent>
+      </div>
+
+      <div className="mt-5 flex items-center justify-center gap-5">
+        <button
+          type="button"
+          onClick={() => api?.scrollPrev()}
+          aria-label="Previous slide"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40"
+        >
+          <ArrowLeft className="h-4 w-4" />
+        </button>
+
+        <div className="flex items-center gap-2.5">
+          {Array.from({ length: snapCount }).map((_, index) => (
+            <button
+              key={index}
+              type="button"
+              onClick={() => api?.scrollTo(index)}
+              aria-label={`Go to slide ${index + 1}`}
+              aria-current={index === currentSlide ? "true" : undefined}
+              className={cn(
+                "rounded-full transition-all duration-300 ease-out focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40",
+                index === currentSlide
+                  ? "h-2 w-7 bg-indigo-500"
+                  : "h-2 w-2 bg-gray-600 hover:bg-gray-400"
+              )}
+            />
+          ))}
+        </div>
+
+        <button
+          type="button"
+          onClick={() => api?.scrollNext()}
+          aria-label="Next slide"
+          className="flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition-colors hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-indigo-400/40"
+        >
+          <ArrowRight className="h-4 w-4" />
+        </button>
+      </div>
+    </Carousel>
+  );
+}

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -4,7 +4,7 @@ import type { Metadata } from "next";
 import { FaTwitch, FaDiscord, FaCoffee } from "react-icons/fa";
 
 export const metadata: Metadata = {
-  title: "About - divoxutils",
+  title: "About",
   description:
     "Learn the story behind divoxutils, why it was built for the DAoC community, and where to follow or support the project.",
   alternates: {
@@ -16,14 +16,14 @@ export const metadata: Metadata = {
       "Learn the story behind divoxutils and how to follow, support, and help shape the project.",
     url: "https://divoxutils.com/about",
     type: "website",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
   twitter: {
     card: "summary_large_image",
     title: "About divoxutils",
     description:
       "Learn the story behind divoxutils and how to follow, support, and help shape the project.",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/admin/accounts/page.tsx
+++ b/src/app/admin/accounts/page.tsx
@@ -3,7 +3,7 @@ import { isAdminClerkUserId } from "@/server/adminAuth";
 import AdminAccountsClient from "./_components/AdminAccountsClient";
 
 export const metadata = {
-  title: "Admin Account Removal - divoxutils",
+  title: "Admin Account Removal",
 };
 
 export default async function AdminAccountRemovalPage() {

--- a/src/app/admin/drafts/page.tsx
+++ b/src/app/admin/drafts/page.tsx
@@ -3,7 +3,7 @@ import { isAdminClerkUserId } from "@/server/adminAuth";
 import AdminDraftModerationClient from "./_components/AdminDraftModerationClient";
 
 export const metadata = {
-  title: "Admin Draft Moderation - divoxutils",
+  title: "Admin Draft Moderation",
 };
 
 export default async function AdminDraftModerationPage() {

--- a/src/app/admin/identity-claims/page.tsx
+++ b/src/app/admin/identity-claims/page.tsx
@@ -3,7 +3,7 @@ import AdminIdentityClaimsClient from "./_components/AdminIdentityClaimsClient";
 import { isAdminClerkUserId } from "@/server/adminAuth";
 
 export const metadata = {
-  title: "Admin Identity Claims - divoxutils",
+  title: "Admin Identity Claims",
 };
 
 export default async function AdminIdentityClaimsPage() {

--- a/src/app/admin/identity-linking/page.tsx
+++ b/src/app/admin/identity-linking/page.tsx
@@ -3,7 +3,7 @@ import { isAdminClerkUserId } from "@/server/adminAuth";
 import AdminIdentityLinkingClient from "./_components/AdminIdentityLinkingClient";
 
 export const metadata = {
-  title: "Admin Identity Linking - divoxutils",
+  title: "Admin Identity Linking",
 };
 
 export default async function AdminIdentityLinkingPage() {

--- a/src/app/admin/layout.tsx
+++ b/src/app/admin/layout.tsx
@@ -1,0 +1,11 @@
+import type { Metadata } from "next";
+import type { ReactNode } from "react";
+import { NOINDEX_METADATA } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...NOINDEX_METADATA,
+};
+
+export default function AdminLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/admin/page.tsx
+++ b/src/app/admin/page.tsx
@@ -3,7 +3,7 @@ import { auth } from "@clerk/nextjs/server";
 import { isAdminClerkUserId } from "@/server/adminAuth";
 
 export const metadata = {
-  title: "Admin - divoxutils",
+  title: "Admin",
 };
 
 export default async function AdminPage() {

--- a/src/app/admin/supporters/page.tsx
+++ b/src/app/admin/supporters/page.tsx
@@ -3,7 +3,7 @@ import { isAdminClerkUserId } from "@/server/adminAuth";
 import AdminSupportersClient from "./_components/AdminSupportersClient";
 
 export const metadata = {
-  title: "Admin Supporters - divoxutils",
+  title: "Admin Supporters",
 };
 
 export default async function AdminSupportersPage() {

--- a/src/app/billing/layout.tsx
+++ b/src/app/billing/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { NOINDEX_METADATA } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...NOINDEX_METADATA,
+};
+
+import type { ReactNode } from "react";
+
+export default function BillingLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/billing/page.tsx
+++ b/src/app/billing/page.tsx
@@ -17,7 +17,7 @@ import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus"
 import BillingClient from "./_components/BillingClient";
 
 export const metadata = {
-  title: "Billing - divoxutils",
+  title: "Billing",
 };
 
 type BillingPageProps = {

--- a/src/app/character-search/page.tsx
+++ b/src/app/character-search/page.tsx
@@ -1,15 +1,14 @@
-import React from "react";
+import { redirect } from "next/navigation";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata = {
-  title: "Search Characters - divoxutils",
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Character search",
+  description:
+    "Search Dark Age of Camelot (DAoC) players and browse public character rosters on divoxutils.",
+  path: "/character-search",
+});
 
-const CharacterSearchPage = () => {
-  return (
-    <div className="bg-gray-900 min-h-screen">
-      {/* <CharacterNameSearch /> */}
-    </div>
-  );
-};
-
-export default CharacterSearchPage;
+export default function CharacterSearchPage() {
+  redirect("/search");
+}

--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -8,7 +8,7 @@ import { getTierFromPriceId, getStripePriceMap } from "@/server/billing/stripe";
 import { isActiveSubscriptionStatus } from "@/server/billing/subscriptionStatus";
 
 export const metadata: Metadata = {
-  title: "Contribute - divoxutils",
+  title: "Contribute",
   description:
     "Support the project and help keep divoxutils online.",
   alternates: {
@@ -19,13 +19,13 @@ export const metadata: Metadata = {
     description: "Support the project and help keep divoxutils online.",
     url: "https://divoxutils.com/contribute",
     type: "website",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
   twitter: {
     card: "summary_large_image",
     title: "Contribute to divoxutils",
     description: "Support the project and help keep divoxutils online.",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -1,0 +1,13 @@
+import type { Metadata } from "next";
+import { NOINDEX_METADATA } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: "Dashboard",
+  ...NOINDEX_METADATA,
+};
+
+import type { ReactNode } from "react";
+
+export default function DashboardLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/discord/page.tsx
+++ b/src/app/discord/page.tsx
@@ -1,30 +1,15 @@
 import { FaDiscord } from "react-icons/fa";
 import Image from "next/image";
 import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Discord Bot - divoxutils",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Discord bot",
   description:
-    "Explore divoxutils Discord bot commands for character lookups, stat comparisons, and draft tools in your server.",
-  alternates: {
-    canonical: "https://divoxutils.com/discord",
-  },
-  openGraph: {
-    title: "Discord Bot - divoxutils",
-    description:
-      "Use the divoxutils Discord bot for character lookups, comparisons, and draft workflows.",
-    url: "https://divoxutils.com/discord",
-    type: "website",
-    images: ["/wh-big.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Discord Bot - divoxutils",
-    description:
-      "Use the divoxutils Discord bot for character lookups, comparisons, and draft workflows.",
-    images: ["/wh-big.png"],
-  },
-};
+    "divoxutils Discord bot commands for Dark Age of Camelot (DAoC): character lookups, stat comparisons, user stats, and live drafts.",
+  path: "/discord",
+  openGraphTitle: "DAoC Discord bot — divoxutils",
+});
 
 const COMMANDS = [
   { id: "draft", label: "/draft" },

--- a/src/app/draft-history/class-leaderboard/page.tsx
+++ b/src/app/draft-history/class-leaderboard/page.tsx
@@ -1,8 +1,18 @@
+import type { Metadata } from "next";
 import { allClasses } from "@/app/draft/_lib/constants";
 import { getClassDraftStats } from "@/server/draftStats";
 import ClassLeaderboardClient from "./_components/ClassLeaderboardClient";
+import { buildPageMetadata } from "@/lib/seo";
 
 export const revalidate = 60;
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Class draft leaderboard",
+  description:
+    "Dark Age of Camelot (DAoC) class-specific draft stats and leaderboards on divoxutils.",
+  path: "/draft-history/class-leaderboard",
+  openGraphTitle: "DAoC class draft leaderboard — divoxutils",
+});
 
 export default async function ClassLeaderboardPage({
   searchParams,

--- a/src/app/draft-history/leaderboard/[clerkUserId]/page.tsx
+++ b/src/app/draft-history/leaderboard/[clerkUserId]/page.tsx
@@ -1,8 +1,15 @@
+import type { Metadata } from "next";
 import { getPlayerDraftDrilldownStats } from "@/server/draftStats";
 import { getClerkUserIdFromLeaderboardParam } from "@/lib/draftHistoryLeaderboardPath";
 import PlayerDrilldownClient from "./_components/PlayerDrilldownClient";
+import { NOINDEX_METADATA } from "@/lib/seo";
 
 export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: "Draft player stats",
+  ...NOINDEX_METADATA,
+};
 
 export default async function PlayerDrilldownPage({
   params,

--- a/src/app/draft-history/leaderboard/page.tsx
+++ b/src/app/draft-history/leaderboard/page.tsx
@@ -4,9 +4,16 @@ import LeaderboardClient from "./_components/LeaderboardClient";
 export const dynamic = "force-dynamic";
 export const revalidate = 60;
 
-export const metadata = {
-  title: "Draft Leaderboard - divoxutils",
-};
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Draft leaderboard",
+  description:
+    "Dark Age of Camelot (DAoC) draft leaderboard on divoxutils. Compare overall draft performance across community players.",
+  path: "/draft-history/leaderboard",
+  openGraphTitle: "DAoC draft leaderboard — divoxutils",
+});
 
 export default async function DraftLeaderboardPage() {
   const rows = await getOverallDraftStats({});

--- a/src/app/draft-history/live/page.tsx
+++ b/src/app/draft-history/live/page.tsx
@@ -1,14 +1,20 @@
 import Image from "next/image";
 import Link from "next/link";
 import { User } from "lucide-react";
+import type { Metadata } from "next";
 import { getLiveDraftRows } from "@/server/draftLive";
 import LiveDraftsAutoRefresh from "./_components/LiveDraftsAutoRefresh";
+import { buildPageMetadata } from "@/lib/seo";
 
 export const revalidate = 15;
 
-export const metadata = {
-  title: "Live Drafts - divoxutils",
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Live drafts",
+  description:
+    "Watch live Dark Age of Camelot (DAoC) community drafts on divoxutils as they happen.",
+  path: "/draft-history/live",
+  openGraphTitle: "Live DAoC drafts — divoxutils",
+});
 
 const STATUS_LABEL: Record<string, string> = {
   setup: "Setup",

--- a/src/app/draft-history/page.tsx
+++ b/src/app/draft-history/page.tsx
@@ -1,12 +1,18 @@
+import type { Metadata } from "next";
 import { getDraftLogRows } from "@/server/draftStats";
 import DraftHistoryClient from "./_components/DraftHistoryClient";
+import { buildPageMetadata } from "@/lib/seo";
 
 export const dynamic = "force-dynamic";
 export const revalidate = 60;
 
-export const metadata = {
-  title: "Draft History - divoxutils",
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Draft history",
+  description:
+    "Dark Age of Camelot (DAoC) community draft history on divoxutils. Browse past draft events, outcomes, and player participation.",
+  path: "/draft-history",
+  openGraphTitle: "DAoC draft history — divoxutils",
+});
 
 export default async function DraftHistoryPage() {
   const rows = await getDraftLogRows();

--- a/src/app/draft/[id]/page.tsx
+++ b/src/app/draft/[id]/page.tsx
@@ -1,7 +1,7 @@
 import DraftClient from "./_components/DraftClient";
 
 export const metadata = {
-  title: "Draft - divoxutils",
+  title: "Draft",
 };
 
 export default function DraftPage({

--- a/src/app/draft/page.tsx
+++ b/src/app/draft/page.tsx
@@ -1,4 +1,14 @@
-"use client";
+import React from "react";
+import type { Metadata } from "next";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Drafts",
+  description:
+    "Dark Age of Camelot (DAoC) community drafts on divoxutils. Start drafts in Discord or browse draft history and leaderboards.",
+  path: "/draft",
+  openGraphTitle: "DAoC drafts — divoxutils",
+});
 
 export default function DraftPage() {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,13 @@ import SupportPromptModal from "@/components/support/SupportPromptModal";
 import SignedOutNudge from "@/components/auth/SignedOutNudge";
 import { getLayoutViewerContext } from "@/server/layoutViewerContext";
 import { isPayPalSubscriptionsEnabled } from "@/server/billing/paypal";
+import JsonLd from "@/components/seo/JsonLd";
+import {
+  DEFAULT_DESCRIPTION,
+  OG_IMAGE_PATH,
+  SITE_NAME,
+  SITE_URL,
+} from "@/lib/seo";
 
 const inter = Inter({
   subsets: ["latin"],
@@ -22,21 +29,45 @@ const inter = Inter({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL('https://divoxutils.com'),
-  title: "divoxutils",
-  description:
-    "divoxutils is a hub for Dark Age of Camelot players. Join us to track your progress, share your milestones, and shape the future of this evolving platform",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "divoxutils — Dark Age of Camelot (DAoC) tools",
+    template: "%s | divoxutils",
+  },
+  description: DEFAULT_DESCRIPTION,
   openGraph: {
-    title: "divoxutils",
-    description: "divoxutils is a hub for Dark Age of Camelot players. Join us to track your progress, share your milestones, and shape the future of this evolving platform",
-    images: ["/wh-big.png"],
-    url: "https://divoxutils.com",
+    title: "divoxutils — Dark Age of Camelot (DAoC) tools",
+    description: DEFAULT_DESCRIPTION,
+    images: [OG_IMAGE_PATH],
+    url: SITE_URL,
     type: "website",
+    siteName: SITE_NAME,
   },
   twitter: {
     card: "summary_large_image",
-    images: ["/wh-big.png"],
+    images: [OG_IMAGE_PATH],
   },
+};
+
+const websiteJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: SITE_NAME,
+  url: SITE_URL,
+  description: DEFAULT_DESCRIPTION,
+  about: {
+    "@type": "VideoGame",
+    name: "Dark Age of Camelot",
+    alternateName: ["DAoC"],
+  },
+};
+
+const organizationJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: SITE_NAME,
+  url: SITE_URL,
+  description: DEFAULT_DESCRIPTION,
 };
 
 export default async function RootLayout({
@@ -50,6 +81,7 @@ export default async function RootLayout({
   return (
     <html lang="en">
       <body className={`${inter.className} antialiased`}>
+        <JsonLd data={[websiteJsonLd, organizationJsonLd]} />
         <ClerkProvider
           appearance={{
             variables: {

--- a/src/app/leaderboards/page.tsx
+++ b/src/app/leaderboards/page.tsx
@@ -4,29 +4,15 @@ import LeaderboardWrapper from "./_components/LeaderboardWrapper";
 import LeaderboardTooltip from "./_components/LeaderboardTooltip";
 import EventScheduleBanner from "./_components/EventScheduleBanner";
 import { getLeaderboardData, type LeaderboardItem } from "@/server/leaderboard";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Leaderboards - divoxutils",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Leaderboards",
   description:
-    "Browse divoxutils leaderboards to see top players, rankings, and progress across the DAoC community.",
-  alternates: {
-    canonical: "https://divoxutils.com/leaderboards",
-  },
-  openGraph: {
-    title: "Leaderboards - divoxutils",
-    description:
-      "See top players and rankings on the divoxutils leaderboards.",
-    url: "https://divoxutils.com/leaderboards",
-    type: "website",
-    images: ["/wh-big.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Leaderboards - divoxutils",
-    description: "See top players and rankings on the divoxutils leaderboards.",
-    images: ["/wh-big.png"],
-  },
-};
+    "Dark Age of Camelot (DAoC) community leaderboards on divoxutils. Compare realm points, rankings, and character progress across tracked players.",
+  path: "/leaderboards",
+  openGraphTitle: "DAoC leaderboards — divoxutils",
+});
 
 export const revalidate = 60;
 

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,38 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "divoxutils — Dark Age of Camelot (DAoC) community tools";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OpenGraphImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: 72,
+          background: "linear-gradient(135deg, #0f172a 0%, #1e1b4b 50%, #111827 100%)",
+          color: "#f9fafb",
+          fontFamily: "system-ui, sans-serif",
+        }}
+      >
+        <div style={{ fontSize: 28, color: "#a5b4fc", marginBottom: 16, letterSpacing: 2 }}>
+          DARK AGE OF CAMELOT
+        </div>
+        <div style={{ fontSize: 88, fontWeight: 800, lineHeight: 1, marginBottom: 24 }}>
+          <span style={{ color: "#818cf8" }}>divox</span>
+          <span>utils</span>
+        </div>
+        <div style={{ fontSize: 32, color: "#d1d5db", maxWidth: 900, lineHeight: 1.4 }}>
+          Character tracking, leaderboards, drafts, Discord bot
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,30 +2,15 @@ import React from "react";
 import Link from "next/link";
 import type { Metadata } from "next";
 import HomeCarousel from "./_components/HomeCarousel";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Home - divoxutils",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Home",
   description:
-    "divoxutils helps Dark Age of Camelot players track characters, compare stats, and stay connected to progress and milestones.",
-  alternates: {
-    canonical: "https://divoxutils.com",
-  },
-  openGraph: {
-    title: "divoxutils",
-    description:
-      "Track characters, compare progress, and follow Dark Age of Camelot leaderboards on divoxutils.",
-    url: "https://divoxutils.com",
-    type: "website",
-    images: ["/wh-big.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "divoxutils",
-    description:
-      "Track characters, compare progress, and follow Dark Age of Camelot leaderboards on divoxutils.",
-    images: ["/wh-big.png"],
-  },
-};
+    "divoxutils is a Dark Age of Camelot (DAoC) community tools site for character tracking, leaderboards, realm rank reference, draft history, Discord bot commands, and Ghost UI.",
+  path: "/",
+  openGraphTitle: "divoxutils — Dark Age of Camelot (DAoC) tools",
+});
 
 export default function HomePage() {
   return (

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,25 +1,25 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Privacy Policy - divoxutils",
+  title: "Privacy Policy",
   description:
     "Read the divoxutils privacy policy covering account data, Stripe billing metadata, and service operations.",
   alternates: {
     canonical: "https://divoxutils.com/privacy",
   },
   openGraph: {
-    title: "Privacy Policy - divoxutils",
+    title: "Privacy Policy",
     description:
       "Read how divoxutils handles account and subscription-related data.",
     url: "https://divoxutils.com/privacy",
     type: "website",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Privacy Policy - divoxutils",
+    title: "Privacy Policy",
     description: "Read how divoxutils handles account and subscription-related data.",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/realm-ranks/page.tsx
+++ b/src/app/realm-ranks/page.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+import type { Metadata } from "next";
 import { OFFICIAL_REALM_RANK_MAX, getRealmRanks } from "@/utils/character";
+import { buildPageMetadata } from "@/lib/seo";
 
 function formatRankKey(numeric: number): string {
   const s = numeric.toString();
@@ -11,9 +13,13 @@ function parseRankToNumeric(key: string): number {
   return parseInt(major, 10) * 10 + parseInt(minor, 10);
 }
 
-export const metadata = {
-  title: "Realm Ranks - divoxutils",
-};
+export const metadata: Metadata = buildPageMetadata({
+  title: "Realm rank chart",
+  description:
+    "Dark Age of Camelot (DAoC) realm rank and realm points reference chart. Look up official realm rank thresholds on divoxutils.",
+  path: "/realm-ranks",
+  openGraphTitle: "DAoC realm rank chart — divoxutils",
+});
 
 export default function RealmRanksPage() {
   const realmRanksMap = getRealmRanks();

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,22 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/seo";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+      disallow: [
+        "/admin/",
+        "/dashboard",
+        "/billing",
+        "/user-characters",
+        "/test/",
+        "/sign-in",
+        "/sign-up",
+        "/api/",
+      ],
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -6,29 +6,15 @@ import SearchUserListToggle from "./_components/SearchUserListToggle";
 import UserListSkeleton from "./_components/UserListSkeleton";
 import { SearchProvider } from "./_lib/SearchContext";
 import { shouldHideUserListForQuery } from "./_lib/urlState";
+import { buildPageMetadata } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "Search Users - divoxutils",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Player search",
   description:
-    "Search for players and characters on divoxutils to quickly find profiles, progress, and related stats.",
-  alternates: {
-    canonical: "https://divoxutils.com/search",
-  },
-  openGraph: {
-    title: "Search Users - divoxutils",
-    description:
-      "Search players and characters on divoxutils.",
-    url: "https://divoxutils.com/search",
-    type: "website",
-    images: ["/wh-big.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Search Users - divoxutils",
-    description: "Search players and characters on divoxutils.",
-    images: ["/wh-big.png"],
-  },
-};
+    "Search Dark Age of Camelot (DAoC) players and characters on divoxutils. Find public character rosters, realm points, and progress.",
+  path: "/search",
+  openGraphTitle: "DAoC player search — divoxutils",
+});
 
 interface SearchPageProps {
   searchParams?: Record<string, string | string[] | undefined>;

--- a/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,8 +1,10 @@
 import { SignIn } from "@clerk/nextjs";
 import type { Metadata } from "next";
+import { NOINDEX_METADATA } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Sign In - divoxutils",
+  title: "Sign In",
+  ...NOINDEX_METADATA,
 };
 
 const SignInPage = () => {

--- a/src/app/sign-up/[[...sign-up]]/page.tsx
+++ b/src/app/sign-up/[[...sign-up]]/page.tsx
@@ -1,9 +1,11 @@
 import { SignUp } from "@clerk/nextjs";
 import type { Metadata } from "next";
 import React from "react";
+import { NOINDEX_METADATA } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "Sign Up - divoxutils",
+  title: "Sign Up",
+  ...NOINDEX_METADATA,
 };
 
 const SignUpPage = () => {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,31 @@
+import type { MetadataRoute } from "next";
+import { getPublicUsers } from "@/server/users";
+import { buildAbsoluteUrl, PUBLIC_SITEMAP_PATHS, SITE_URL } from "@/lib/seo";
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const now = new Date();
+  const staticEntries: MetadataRoute.Sitemap = PUBLIC_SITEMAP_PATHS.map((path) => ({
+    url: buildAbsoluteUrl(path),
+    lastModified: now,
+    changeFrequency: path === "/" ? "weekly" : "daily",
+    priority: path === "/" ? 1 : path === "/about" || path === "/search" ? 0.9 : 0.8,
+  }));
+
+  let userEntries: MetadataRoute.Sitemap = [];
+  try {
+    const users = await getPublicUsers();
+    userEntries = users
+      .filter((user) => user.name?.trim())
+      .slice(0, 5000)
+      .map((user) => ({
+        url: `${SITE_URL}/user/${encodeURIComponent(user.name)}/characters`,
+        lastModified: now,
+        changeFrequency: "daily" as const,
+        priority: 0.6,
+      }));
+  } catch {
+    userEntries = [];
+  }
+
+  return [...staticEntries, ...userEntries];
+}

--- a/src/app/support/page.tsx
+++ b/src/app/support/page.tsx
@@ -1,24 +1,24 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Support - divoxutils",
+  title: "Support",
   description:
     "Get help with divoxutils account, billing, and support questions.",
   alternates: {
     canonical: "https://divoxutils.com/support",
   },
   openGraph: {
-    title: "Support - divoxutils",
+    title: "Support",
     description: "Get help with divoxutils account, billing, and support questions.",
     url: "https://divoxutils.com/support",
     type: "website",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Support - divoxutils",
+    title: "Support",
     description: "Get help with divoxutils account, billing, and support questions.",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/terms/page.tsx
+++ b/src/app/terms/page.tsx
@@ -1,25 +1,25 @@
 import type { Metadata } from "next";
 
 export const metadata: Metadata = {
-  title: "Terms of Service - divoxutils",
+  title: "Terms of Service",
   description:
     "Review the divoxutils terms of service, including account responsibilities and subscription terms.",
   alternates: {
     canonical: "https://divoxutils.com/terms",
   },
   openGraph: {
-    title: "Terms of Service - divoxutils",
+    title: "Terms of Service",
     description:
       "Review divoxutils terms for account usage and supporter subscriptions.",
     url: "https://divoxutils.com/terms",
     type: "website",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
   twitter: {
     card: "summary_large_image",
-    title: "Terms of Service - divoxutils",
+    title: "Terms of Service",
     description: "Review divoxutils terms for account usage and supporter subscriptions.",
-    images: ["/wh-big.png"],
+    images: ["/opengraph-image"],
   },
 };
 

--- a/src/app/test/layout.tsx
+++ b/src/app/test/layout.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { NOINDEX_METADATA } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  ...NOINDEX_METADATA,
+};
+
+import type { ReactNode } from "react";
+
+export default function TestLayout({ children }: { children: ReactNode }) {
+  return children;
+}

--- a/src/app/tools/page.tsx
+++ b/src/app/tools/page.tsx
@@ -1,0 +1,114 @@
+import React from "react";
+import Link from "next/link";
+import type { Metadata } from "next";
+import { Swords } from "lucide-react";
+import { FaDiscord } from "react-icons/fa";
+import {
+  HiMagnifyingGlass,
+  HiTrophy,
+  HiChartBar,
+  HiStar,
+  HiEye,
+  HiInformationCircle,
+} from "react-icons/hi2";
+import { buildPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "DAoC tools",
+  description:
+    "Browse Dark Age of Camelot (DAoC) tools on divoxutils: character tracking, player search, leaderboards, realm ranks, draft history, Discord bot, and Ghost UI.",
+  path: "/tools",
+  openGraphTitle: "Dark Age of Camelot tools on divoxutils",
+});
+
+const TOOLS = [
+  {
+    href: "/search",
+    name: "Player search",
+    summary: "Find players and characters.",
+    icon: <HiMagnifyingGlass className="h-5 w-5 text-indigo-400" />,
+  },
+  {
+    href: "/leaderboards",
+    name: "Leaderboards",
+    summary: "Rankings and progression.",
+    icon: <HiTrophy className="h-5 w-5 text-indigo-400" />,
+  },
+  {
+    href: "/realm-ranks",
+    name: "Realm rank chart",
+    summary: "Realm rank thresholds and realm point reference table.",
+    icon: <HiChartBar className="h-5 w-5 text-indigo-400" />,
+  },
+  {
+    href: "/draft-history",
+    name: "Draft history",
+    summary: "Past and live draft events, results, and stats.",
+    icon: <Swords className="h-5 w-5 text-indigo-400" strokeWidth={2} />,
+  },
+  {
+    href: "/draft-history/leaderboard",
+    name: "Draft leaderboard",
+    summary: "Overall draft performance compared across community players.",
+    icon: <HiStar className="h-5 w-5 text-indigo-400" />,
+  },
+  {
+    href: "/discord",
+    name: "Discord bot",
+    summary: "Slash commands for character lookups, comparisons, and live drafts.",
+    icon: <FaDiscord className="h-5 w-5 text-indigo-400" />,
+  },
+  {
+    href: "/ui",
+    name: "Ghost UI",
+    summary: "In-game user interface download for Dark Age of Camelot on Windows.",
+    icon: <HiEye className="h-5 w-5 text-indigo-400" />,
+  },
+  {
+    href: "/about",
+    name: "About",
+    summary: "The story behind divoxutils and community links.",
+    icon: <HiInformationCircle className="h-5 w-5 text-indigo-400" />,
+  },
+];
+
+export default function ToolsPage() {
+  return (
+    <div className="bg-gray-900 min-h-screen text-gray-300">
+      <div className="mx-auto max-w-3xl px-4 py-16 space-y-12">
+        <header className="space-y-4">
+          <h1 className="text-2xl font-bold text-white tracking-tight">
+            Tools
+          </h1>
+        </header>
+
+        <section aria-labelledby="tools-list-heading">
+          <h2 id="tools-list-heading" className="sr-only">
+            Tool list
+          </h2>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {TOOLS.map((tool) => (
+              <Link
+                key={tool.href}
+                href={tool.href}
+                className="group flex items-start gap-4 rounded-xl border border-gray-800 bg-gray-800/30 px-5 py-4 transition-all hover:border-indigo-500/40 hover:bg-gray-800/60"
+              >
+                <span className="mt-0.5 shrink-0 rounded-lg bg-gray-700/50 p-2 transition-colors group-hover:bg-indigo-500/10">
+                  {tool.icon}
+                </span>
+                <div className="min-w-0">
+                  <h3 className="text-sm font-semibold text-white group-hover:text-indigo-300 transition-colors">
+                    {tool.name}
+                  </h3>
+                  <p className="mt-1 text-xs text-gray-500 leading-relaxed">
+                    {tool.summary}
+                  </p>
+                </div>
+              </Link>
+            ))}
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/src/app/ui/page.tsx
+++ b/src/app/ui/page.tsx
@@ -1,25 +1,35 @@
 import React from "react";
 import type { Metadata } from "next";
 import { HiArrowDownTray } from "react-icons/hi2";
+import { buildPageMetadata, SITE_URL } from "@/lib/seo";
+import JsonLd from "@/components/seo/JsonLd";
 
-export const metadata: Metadata = {
-  title: "Ghost UI - divoxutils",
-  description: "Download Ghost UI for Dark Age of Camelot.",
-  alternates: {
-    canonical: "https://divoxutils.com/ui",
+export const metadata: Metadata = buildPageMetadata({
+  title: "Ghost UI",
+  description:
+    "Download Ghost UI for Dark Age of Camelot (DAoC) — a custom in-game overlay for realm rank charts and related player info on divoxutils.",
+  path: "/ui",
+  openGraphTitle: "Ghost UI for DAoC — divoxutils",
+});
+
+const ghostUiJsonLd = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: "Ghost UI",
+  applicationCategory: "GameApplication",
+  operatingSystem: "Windows",
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
   },
-  openGraph: {
-    title: "Ghost UI - divoxutils",
-    description: "Download Ghost UI for Dark Age of Camelot.",
-    url: "https://divoxutils.com/ui",
-    type: "website",
-    images: ["/wh-big.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "Ghost UI - divoxutils",
-    description: "Download Ghost UI for Dark Age of Camelot.",
-    images: ["/wh-big.png"],
+  description:
+    "Custom Dark Age of Camelot UI overlay distributed by divoxutils for realm rank and related in-game information.",
+  url: `${SITE_URL}/ui`,
+  publisher: {
+    "@type": "Organization",
+    name: "divoxutils",
+    url: SITE_URL,
   },
 };
 
@@ -76,6 +86,7 @@ const CHANGELOG: {
 export default function UiPage() {
   return (
     <div className="bg-gray-900 min-h-screen text-gray-300">
+      <JsonLd data={ghostUiJsonLd} />
       <div className="mx-auto max-w-3xl px-4 py-16 space-y-16">
         <header className="space-y-4">
           <h1 className="text-2xl font-bold text-white tracking-tight">

--- a/src/app/user-characters/page.tsx
+++ b/src/app/user-characters/page.tsx
@@ -14,29 +14,11 @@ import { getLeaderboardProfileHref } from "@/lib/draftHistoryLeaderboardPath";
 import type { Metadata } from "next";
 import { isCharacterListLayout } from "@/server/characterListLayoutPreference";
 import { getLeaderboardData } from "@/server/leaderboard";
+import { NOINDEX_METADATA } from "@/lib/seo";
 
 export const metadata: Metadata = {
-  title: "My Characters - divoxutils",
-  description:
-    "Manage your Dark Age of Camelot characters on divoxutils.",
-  alternates: {
-    canonical: "https://divoxutils.com/user-characters",
-  },
-  openGraph: {
-    title: "My Characters - divoxutils",
-    description:
-      "Manage your Dark Age of Camelot characters on divoxutils.",
-    url: "https://divoxutils.com/user-characters",
-    type: "website",
-    images: ["/wh-big.png"],
-  },
-  twitter: {
-    card: "summary_large_image",
-    title: "My Characters - divoxutils",
-    description:
-      "Manage your Dark Age of Camelot characters on divoxutils.",
-    images: ["/wh-big.png"],
-  },
+  title: "My Characters",
+  ...NOINDEX_METADATA,
 };
 
 const CharacterListOptimized = dynamic(

--- a/src/app/user/[name]/characters/page.tsx
+++ b/src/app/user/[name]/characters/page.tsx
@@ -40,7 +40,7 @@ export async function generateMetadata(
 
   if (!user) {
     return {
-      title: "User Not Found - divoxutils",
+      title: "User Not Found",
       description: "This profile could not be found on divoxutils.",
     };
   }
@@ -49,25 +49,26 @@ export async function generateMetadata(
   const pathSegment =
     typeof resolvedParams.name === "string" ? resolvedParams.name : displayName;
   const profileUrl = `https://divoxutils.com/user/${encodeURIComponent(pathSegment)}/characters`;
+  const description = `Track ${displayName}'s Dark Age of Camelot (DAoC) characters on divoxutils — realm points, realm ranks, realms, and progress across their roster.`;
 
   return {
-    title: `${displayName}'s characters - divoxutils`,
-    description: `See ${displayName}'s characters on divoxutils.`,
+    title: `${displayName}'s DAoC characters`,
+    description,
     alternates: {
       canonical: profileUrl,
     },
     openGraph: {
-      title: `${displayName}'s characters`,
-      description: `See ${displayName}'s characters on divoxutils.`,
+      title: `${displayName}'s DAoC characters`,
+      description,
       url: profileUrl,
-      type: "website",
-      images: ["/wh-big.png"],
+      type: "profile",
+      images: ["/opengraph-image"],
     },
     twitter: {
       card: "summary_large_image",
-      title: `${displayName}'s characters`,
-      description: `See ${displayName}'s characters on divoxutils.`,
-      images: ["/wh-big.png"],
+      title: `${displayName}'s DAoC characters`,
+      description,
+      images: ["/opengraph-image"],
     },
   };
 }

--- a/src/app/users/[userId]/characters/page.tsx
+++ b/src/app/users/[userId]/characters/page.tsx
@@ -1,107 +1,25 @@
-import React from "react";
-import dynamic from "next/dynamic";
-import { PageReload } from "@/app/user/_components/PageReload";
-import { Suspense } from "react";
-import Loading from "@/app/loading";
+import { redirect } from "next/navigation";
 import prisma from "../../../../../prisma/prismaClient";
-import { getLeaderboardProfileHref } from "@/lib/draftHistoryLeaderboardPath";
-import DraftProfileButton from "@/app/user/_components/DraftProfileButton";
-import { getCurrentUserCharacterListLayoutPreference } from "@/server/characterListLayoutPreference";
-import { getLeaderboardData } from "@/server/leaderboard";
 
-const CharacterListOptimized = dynamic(
-  () => import("@/app/_components/characters/CharacterListOptimized"),
-  {
-    loading: () => {
-      const CharacterListSkeleton = require("@/app/user/_components/CharacterListSkeleton").default;
-      return <CharacterListSkeleton />;
-    },
-  }
-);
-
-interface CharactersPageProps {
-  params?: Promise<any>;
-  searchParams?: Promise<any>;
+interface LegacyCharactersPageProps {
+  params: Promise<{ userId: string }>;
 }
 
-async function fetchCharactersForUser(userId: string) {
-  const apiUrl = `${process.env.NEXT_PUBLIC_API_URL}/api/userCharactersByUserId/${userId}`;
-  const response = await fetch(apiUrl, {
-    cache: "no-store",
+export default async function LegacyUserCharactersPage({ params }: LegacyCharactersPageProps) {
+  const { userId } = await params;
+
+  if (!userId) {
+    redirect("/search");
+  }
+
+  const user = await prisma.user.findUnique({
+    where: { clerkUserId: userId },
+    select: { name: true },
   });
-  if (!response.ok) {
-    console.error(
-      `Fetch response error: ${response.status} ${response.statusText}`
-    );
-    throw new Error(
-      `Fetch response error: ${response.status} ${response.statusText}`
-    );
-  }
-  return await response.json();
-}
 
-export default async function CharactersPage({
-  params,
-  searchParams,
-}: CharactersPageProps) {
-  const resolvedParams = (await (params ?? Promise.resolve({}))) as { userId?: string };
-  const resolvedSearchParams = (await (searchParams ?? Promise.resolve({}))) as Record<string, string | string[]>;
-  const userId = resolvedParams.userId as string;
-
-  const [userData, identityLink, preferredDesktopLayout, initialLeaderboardData] = await Promise.all([
-    prisma.user.findUnique({
-      where: { clerkUserId: userId },
-      select: { name: true },
-    }),
-    prisma.userIdentityLink.findFirst({
-      where: {
-        clerkUserId: userId,
-        provider: "discord",
-        status: "linked",
-      },
-      select: { id: true },
-    }),
-    getCurrentUserCharacterListLayoutPreference(),
-    getLeaderboardData(),
-  ]);
-
-  if (!userData) {
-    throw new Error("Failed to fetch user");
+  if (user?.name) {
+    redirect(`/user/${encodeURIComponent(user.name)}/characters`);
   }
 
-  const characters = await fetchCharactersForUser(userId);
-
-  const draftProfileHref = identityLink
-    ? getLeaderboardProfileHref(userId, userData.name ?? undefined)
-    : undefined;
-
-  return (
-    <div className="bg-gray-900 min-h-screen text-gray-300">
-      <div className="p-4 md:p-8 lg:p-12">
-        <div className="max-w-screen-lg mx-auto">
-          <div className="relative flex items-center justify-center mb-4">
-            <h1 className="text-2xl sm:text-3xl font-semibold text-white">
-              {userData.name}
-            </h1>
-            {draftProfileHref && (
-              <div className="absolute right-0">
-                <DraftProfileButton href={draftProfileHref} />
-              </div>
-            )}
-          </div>
-          <PageReload />
-          <Suspense fallback={<Loading />}>
-            <CharacterListOptimized
-              key={userId}
-              characters={characters}
-              searchParams={resolvedSearchParams}
-              showDelete={false}
-              preferredDesktopLayout={preferredDesktopLayout}
-              initialLeaderboardData={initialLeaderboardData}
-            />
-          </Suspense>
-        </div>
-      </div>
-    </div>
-  );
+  redirect("/search");
 }

--- a/src/components/seo/JsonLd.tsx
+++ b/src/components/seo/JsonLd.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+type JsonLdProps = {
+  data: Record<string, unknown> | Record<string, unknown>[];
+};
+
+export default function JsonLd({ data }: JsonLdProps) {
+  const payload = Array.isArray(data) ? data : [data];
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(payload.length === 1 ? payload[0] : payload) }}
+    />
+  );
+}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,256 @@
+"use client";
+
+import * as React from "react";
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react";
+import { ArrowLeft, ArrowRight } from "lucide-react";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+
+type CarouselApi = UseEmblaCarouselType[1];
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>;
+type CarouselOptions = UseCarouselParameters[0];
+type CarouselPlugin = UseCarouselParameters[1];
+
+type CarouselProps = {
+  opts?: CarouselOptions;
+  plugins?: CarouselPlugin;
+  orientation?: "horizontal" | "vertical";
+  spacing?: "default" | "none";
+  setApi?: (api: CarouselApi) => void;
+};
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0];
+  api: ReturnType<typeof useEmblaCarousel>[1];
+  scrollPrev: () => void;
+  scrollNext: () => void;
+  canScrollPrev: boolean;
+  canScrollNext: boolean;
+} & CarouselProps;
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null);
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext);
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />");
+  }
+
+  return context;
+}
+
+const Carousel = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & CarouselProps
+>(
+  (
+    {
+      orientation = "horizontal",
+      spacing = "default",
+      opts,
+      setApi,
+      plugins,
+      className,
+      children,
+      ...props
+    },
+    ref
+  ) => {
+    const [carouselRef, api] = useEmblaCarousel(
+      {
+        ...opts,
+        axis: orientation === "horizontal" ? "x" : "y",
+      },
+      plugins
+    );
+    const [canScrollPrev, setCanScrollPrev] = React.useState(false);
+    const [canScrollNext, setCanScrollNext] = React.useState(false);
+
+    const onSelect = React.useCallback((api: CarouselApi) => {
+      if (!api) return;
+      setCanScrollPrev(api.canScrollPrev());
+      setCanScrollNext(api.canScrollNext());
+    }, []);
+
+    const scrollPrev = React.useCallback(() => {
+      api?.scrollPrev();
+    }, [api]);
+
+    const scrollNext = React.useCallback(() => {
+      api?.scrollNext();
+    }, [api]);
+
+    const handleKeyDown = React.useCallback(
+      (event: React.KeyboardEvent<HTMLDivElement>) => {
+        if (event.key === "ArrowLeft") {
+          event.preventDefault();
+          scrollPrev();
+        } else if (event.key === "ArrowRight") {
+          event.preventDefault();
+          scrollNext();
+        }
+      },
+      [scrollPrev, scrollNext]
+    );
+
+    React.useEffect(() => {
+      if (!api || !setApi) return;
+      setApi(api);
+    }, [api, setApi]);
+
+    React.useEffect(() => {
+      if (!api) return;
+      onSelect(api);
+      api.on("reInit", onSelect);
+      api.on("select", onSelect);
+
+      return () => {
+        api?.off("select", onSelect);
+        api?.off("reInit", onSelect);
+      };
+    }, [api, onSelect]);
+
+    return (
+      <CarouselContext.Provider
+        value={{
+          carouselRef,
+          api,
+          opts,
+          orientation,
+          spacing,
+          scrollPrev,
+          scrollNext,
+          canScrollPrev,
+          canScrollNext,
+        }}
+      >
+        <div
+          ref={ref}
+          onKeyDownCapture={handleKeyDown}
+          className={cn("relative", className)}
+          role="region"
+          aria-roledescription="carousel"
+          {...props}
+        >
+          {children}
+        </div>
+      </CarouselContext.Provider>
+    );
+  }
+);
+Carousel.displayName = "Carousel";
+
+const CarouselContent = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { carouselRef, orientation, spacing } = useCarousel();
+
+  return (
+    <div ref={carouselRef} className="overflow-hidden">
+      <div
+        ref={ref}
+        className={cn(
+          "flex",
+          spacing === "default" && (orientation === "horizontal" ? "-ml-4" : "-mt-4"),
+          orientation === "vertical" && "flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  );
+});
+CarouselContent.displayName = "CarouselContent";
+
+const CarouselItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => {
+  const { orientation, spacing } = useCarousel();
+
+  return (
+    <div
+      ref={ref}
+      role="group"
+      aria-roledescription="slide"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        spacing === "default" && (orientation === "horizontal" ? "pl-4" : "pt-4"),
+        className
+      )}
+      {...props}
+    />
+  );
+});
+CarouselItem.displayName = "CarouselItem";
+
+const CarouselPrevious = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full border-gray-700 bg-gray-900/80 text-gray-300 hover:bg-gray-800 hover:text-white",
+        orientation === "horizontal"
+          ? "-left-4 top-1/2 -translate-y-1/2"
+          : "-top-4 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft className="h-4 w-4" />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  );
+});
+CarouselPrevious.displayName = "CarouselPrevious";
+
+const CarouselNext = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<typeof Button>
+>(({ className, variant = "outline", size = "icon", ...props }, ref) => {
+  const { orientation, scrollNext, canScrollNext } = useCarousel();
+
+  return (
+    <Button
+      ref={ref}
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute h-8 w-8 rounded-full border-gray-700 bg-gray-900/80 text-gray-300 hover:bg-gray-800 hover:text-white",
+        orientation === "horizontal"
+          ? "-right-4 top-1/2 -translate-y-1/2"
+          : "-bottom-4 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight className="h-4 w-4" />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  );
+});
+CarouselNext.displayName = "CarouselNext";
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+};

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,80 @@
+import type { Metadata } from "next";
+
+export const SITE_URL = "https://divoxutils.com";
+export const SITE_NAME = "divoxutils";
+export const OG_IMAGE_PATH = "/opengraph-image";
+
+export const DEFAULT_TITLE = "divoxutils — Dark Age of Camelot (DAoC) tools";
+export const DEFAULT_DESCRIPTION =
+  "divoxutils is a Dark Age of Camelot (DAoC) community hub for character tracking, leaderboards, realm rank reference, draft history, Discord bot commands, and Ghost UI.";
+
+export const NOINDEX_METADATA: Pick<Metadata, "robots"> = {
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export function buildAbsoluteUrl(path: string): string {
+  if (path === "/" || path === "") {
+    return SITE_URL;
+  }
+
+  return `${SITE_URL}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+type PageMetadataInput = {
+  title: string;
+  description: string;
+  path: string;
+  openGraphTitle?: string;
+};
+
+export function buildPageMetadata({
+  title,
+  description,
+  path,
+  openGraphTitle,
+}: PageMetadataInput): Metadata {
+  const canonical = buildAbsoluteUrl(path);
+  const ogTitle = openGraphTitle ?? title;
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title: ogTitle,
+      description,
+      url: canonical,
+      type: "website",
+      images: [OG_IMAGE_PATH],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title: ogTitle,
+      description,
+      images: [OG_IMAGE_PATH],
+    },
+  };
+}
+
+export const PUBLIC_SITEMAP_PATHS = [
+  "/",
+  "/about",
+  "/leaderboards",
+  "/search",
+  "/realm-ranks",
+  "/draft-history",
+  "/draft-history/leaderboard",
+  "/draft-history/live",
+  "/draft-history/class-leaderboard",
+  "/discord",
+  "/ui",
+  "/contribute",
+  "/privacy",
+  "/terms",
+  "/support",
+  "/tools",
+  "/draft",
+] as const;


### PR DESCRIPTION
- Add centralized SEO helpers, sitemap, robots.txt, JSON-LD, and dynamic Open Graph images
- Normalize page titles/canonicals and fix duplicate | divoxutils branding in metadata
- Refactor the homepage carousel (server-rendered slides, accessible controls, gapless layout) and add a /tools slide
- Add a crawlable /tools page; keep most tool pages visually unchanged and remove extra on-page SEO copy
- Redirect legacy URLs (/character-search, old user character paths) and noindex private/auth/admin routes
- Update README and social preview image copy to highlight character tracking, leaderboards, drafts, and Discord bot