### PR TITLE
Add hide profile toggle for characters, leaderboards, and search

### DIFF
--- a/prisma/migrations/20260825120000_add_hide_profile_to_user/migration.sql
+++ b/prisma/migrations/20260825120000_add_hide_profile_to_user/migration.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "User"
+ADD COLUMN "hideProfile" BOOLEAN NOT NULL DEFAULT false;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -37,6 +37,7 @@ model User {
   supporterTier    Int             @default(0)
   supporterAmount  Float           @default(0)
   preferredCharacterListLayout String @default("table")
+  hideProfile      Boolean         @default(false)
   stripeCustomerId String?         @unique
   stripeSubscriptionId String?     @unique
   paypalPayerId String?            @unique

--- a/src/app/api/characters/stats/[name]/route.ts
+++ b/src/app/api/characters/stats/[name]/route.ts
@@ -11,6 +11,7 @@ const handlers = createCharacterStatsByNameRouteHandlers({
             equals: name,
             mode: "insensitive",
           },
+          users: { none: { user: { hideProfile: true } } },
         },
         select: {
           id: true,

--- a/src/app/api/charactersByUser/[id]/route.ts
+++ b/src/app/api/charactersByUser/[id]/route.ts
@@ -1,10 +1,14 @@
 import { getUserCharactersByUserId } from "@/server/services/userCharacterService";
 import { createCharactersByUserIdRouteHandlers } from "@/server/api/charactersByUserIdRouteHandlers";
+import { isAdminClerkUserId } from "@/server/adminAuth";
+import { getClerkAuthUserId } from "@/server/clerkAuth";
 
 const handlers = createCharactersByUserIdRouteHandlers({
   deps: {
     getUserCharactersByUserId,
   },
+  getAuthUserId: getClerkAuthUserId,
+  isAdminClerkUserId,
 });
 
 export const GET = handlers.GET;

--- a/src/app/api/searchUsersAndCharacters/route.ts
+++ b/src/app/api/searchUsersAndCharacters/route.ts
@@ -1,7 +1,9 @@
 import prisma from "../../../../prisma/prismaClient";
 import { createSearchUsersAndCharactersRouteHandlers } from "@/server/searchUsersAndCharactersRouteHandlers";
+import { getClerkAuthUserId } from "@/server/clerkAuth";
 
 const handlers = createSearchUsersAndCharactersRouteHandlers({
+  getAuthUserId: getClerkAuthUserId,
   deps: {
     findUsers: ({ normalizedQuery }) =>
       prisma.user.findMany({

--- a/src/app/api/user/preferences/hide-profile/route.ts
+++ b/src/app/api/user/preferences/hide-profile/route.ts
@@ -1,0 +1,35 @@
+import { revalidateTag } from "next/cache";
+import prisma from "../../../../../../prisma/prismaClient";
+import {
+  type HideProfileApiDeps,
+} from "@/server/hideProfileApi";
+import { createHideProfileRouteHandlers } from "@/server/hideProfileRouteHandlers";
+import { getClerkAuthUserId } from "@/server/clerkAuth";
+
+const deps: HideProfileApiDeps = {
+  findUserHideProfile: (clerkUserId: string) =>
+    prisma.user.findUnique({
+      where: { clerkUserId },
+      select: { hideProfile: true },
+    }),
+  findUserByClerkId: (clerkUserId: string) =>
+    prisma.user.findUnique({
+      where: { clerkUserId },
+      select: { clerkUserId: true },
+    }),
+  updateUserHideProfile: (clerkUserId: string, hideProfile: boolean) =>
+    prisma.user.update({
+      where: { clerkUserId },
+      data: { hideProfile },
+      select: { hideProfile: true },
+    }),
+  revalidatePublicProfile: () => revalidateTag("public-user-profile"),
+};
+
+const handlers = createHideProfileRouteHandlers({
+  getAuthUserId: getClerkAuthUserId,
+  apiDeps: deps,
+});
+
+export const GET = handlers.GET;
+export const PUT = handlers.PUT;

--- a/src/app/api/userCharactersByUserId/[userId]/route.ts
+++ b/src/app/api/userCharactersByUserId/[userId]/route.ts
@@ -1,10 +1,14 @@
 import { createUserCharactersByUserIdRouteHandlers } from "@/server/api/userCharactersByUserIdRouteHandlers";
 import { getUserCharactersByUserId } from "@/server/services/userCharacterService";
+import { isAdminClerkUserId } from "@/server/adminAuth";
+import { getClerkAuthUserId } from "@/server/clerkAuth";
 
 const handlers = createUserCharactersByUserIdRouteHandlers({
   deps: {
     getUserCharactersByUserId,
   },
+  getAuthUserId: getClerkAuthUserId,
+  isAdminClerkUserId,
 });
 
 export const GET = handlers.GET;

--- a/src/app/api/users/stats/[name]/route.ts
+++ b/src/app/api/users/stats/[name]/route.ts
@@ -7,9 +7,10 @@ const handlers = createUsersStatsByNameRouteHandlers({
   deps: {
     getAllUserNames,
     getUserStatsByName: async (name: string) =>
-      prisma.user.findUnique({
+      prisma.user.findFirst({
         where: {
           name,
+          hideProfile: false,
         },
         select: {
           id: true,

--- a/src/app/search/_components/UserAndCharacterSearchResults.tsx
+++ b/src/app/search/_components/UserAndCharacterSearchResults.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import Link from "next/link";
 import { usePathname, useSearchParams } from "next/navigation";
+import { EyeOff } from "lucide-react";
 import useDebounce from "./useDebounce";
 import Loading from "@/app/loading";
 import { buildSearchUrl, shouldHideUserListForQuery } from "../_lib/urlState";
@@ -28,6 +29,7 @@ type User = {
   clerkUserId: string;
   name: string;
   supporterTier: number;
+  isOwnHiddenProfile: boolean;
   characters: Character[];
 };
 
@@ -186,6 +188,16 @@ export default function CharacterNameSearch() {
                         {user.characters.length} character{user.characters.length !== 1 ? "s" : ""}
                       </span>
                     </div>
+
+                    {user.isOwnHiddenProfile && (
+                      <div
+                        className="flex items-center gap-1 text-[11px] text-gray-500 mb-2"
+                        title="Your character list is hidden from other players, but you can still see it here."
+                      >
+                        <EyeOff size={11} strokeWidth={2} />
+                        Only visible to you &mdash; your profile is hidden from other players
+                      </div>
+                    )}
 
                     {user.characters.length > 0 && (
                       <div className="divide-y divide-gray-800">

--- a/src/app/user-characters/_components/HideProfileToggle.tsx
+++ b/src/app/user-characters/_components/HideProfileToggle.tsx
@@ -1,0 +1,96 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+import { toast } from "sonner";
+import { Eye, EyeOff, Info } from "lucide-react";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+interface HideProfileToggleProps {
+  initialHideProfile: boolean;
+}
+
+const HideProfileToggle: React.FC<HideProfileToggleProps> = ({
+  initialHideProfile,
+}) => {
+  const [hideProfile, setHideProfile] = useState(initialHideProfile);
+  const inFlightRequest = useRef<AbortController | null>(null);
+
+  const handleChange = useCallback(
+    async (value: string) => {
+      const nextHideProfile = value === "hidden";
+      if (nextHideProfile === hideProfile) return;
+
+      inFlightRequest.current?.abort();
+      const controller = new AbortController();
+      inFlightRequest.current = controller;
+
+      const previousHideProfile = hideProfile;
+      setHideProfile(nextHideProfile);
+
+      try {
+        const response = await fetch("/api/user/preferences/hide-profile", {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ hideProfile: nextHideProfile }),
+          signal: controller.signal,
+        });
+        if (!response.ok) {
+          throw new Error("Could not save profile visibility");
+        }
+        if (inFlightRequest.current !== controller) return;
+        toast.success(
+          nextHideProfile
+            ? "Your characters are now hidden from other players and leaderboards"
+            : "Your characters are visible again"
+        );
+      } catch (error) {
+        if (error instanceof DOMException && error.name === "AbortError") return;
+        if (inFlightRequest.current !== controller) return;
+        setHideProfile(previousHideProfile);
+        toast.error("Could not save profile visibility");
+      }
+    },
+    [hideProfile]
+  );
+
+  return (
+    <TooltipProvider delayDuration={300}>
+      <div className="inline-flex items-center gap-2 rounded-md border border-gray-800 bg-gray-900/40 pl-2.5 pr-1.5 py-1">
+        {hideProfile ? (
+          <EyeOff size={13} strokeWidth={2} className="text-gray-500 shrink-0" />
+        ) : (
+          <Eye size={13} strokeWidth={2} className="text-gray-500 shrink-0" />
+        )}
+        <span className="text-[11px] font-medium text-gray-400 whitespace-nowrap">
+          Profile
+        </span>
+        <ToggleGroup
+          value={hideProfile ? "hidden" : "visible"}
+          onValueChange={handleChange}
+        >
+          <ToggleGroupItem value="visible">Visible</ToggleGroupItem>
+          <ToggleGroupItem value="hidden">Hidden</ToggleGroupItem>
+        </ToggleGroup>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <span className="flex items-center justify-center text-gray-600 hover:text-gray-400 transition-colors duration-150">
+              <Info size={13} strokeWidth={2} />
+            </span>
+          </TooltipTrigger>
+          <TooltipContent className="max-w-[220px] text-center">
+            Hides your character list from your public profile and
+            leaderboards. You&apos;ll still appear in search.
+          </TooltipContent>
+        </Tooltip>
+      </div>
+    </TooltipProvider>
+  );
+};
+
+export default HideProfileToggle;

--- a/src/app/user-characters/page.tsx
+++ b/src/app/user-characters/page.tsx
@@ -6,6 +6,7 @@ import { Suspense } from "react";
 import Loading from "../loading";
 import ShareProfileButton from "../user/_components/ShareProfileButton";
 import DraftProfileButton from "../user/_components/DraftProfileButton";
+import HideProfileToggle from "./_components/HideProfileToggle";
 import SupporterBadge from "@/components/support/SupporterBadge";
 import { redirect } from "next/navigation";
 import { headers } from "next/headers";
@@ -51,8 +52,10 @@ function getApiBaseUrl() {
 
 async function fetchCharactersForUser(userId: string) {
   const apiUrl = `${getApiBaseUrl()}/api/userCharactersByUserId/${userId}`;
+  const cookie = headers().get("cookie");
   try {
     const response = await fetch(apiUrl, {
+      headers: cookie ? { cookie } : undefined,
       next: {
         revalidate: 0,
         tags: [`user-characters-${userId}`],
@@ -100,7 +103,12 @@ const UserCharactersPage = async ({ searchParams }: UserCharactersPageProps) => 
     fetchCharactersForUser(userId),
     prisma.user.findUnique({
       where: { clerkUserId: userId },
-      select: { supporterTier: true, name: true, preferredCharacterListLayout: true },
+      select: {
+        supporterTier: true,
+        name: true,
+        preferredCharacterListLayout: true,
+        hideProfile: true,
+      },
     }),
     prisma.userIdentityLink.findFirst({
       where: { clerkUserId: userId, provider: "discord", status: "linked" },
@@ -129,9 +137,12 @@ const UserCharactersPage = async ({ searchParams }: UserCharactersPageProps) => 
               My Characters
               {supporterTier > 0 && <SupporterBadge tier={supporterTier} size="md" />}
             </h1>
-            <div className="flex items-center gap-1.5">
-              {draftProfileHref && <DraftProfileButton href={draftProfileHref} />}
-              <ShareProfileButton username={shareUsername} />
+            <div className="flex items-center gap-2">
+              <HideProfileToggle initialHideProfile={dbUser?.hideProfile ?? false} />
+              <div className="flex items-center gap-1.5">
+                {draftProfileHref && <DraftProfileButton href={draftProfileHref} />}
+                <ShareProfileButton username={shareUsername} />
+              </div>
             </div>
           </div>
           <CharacterSearchAndAdd />

--- a/src/app/user/[name]/characters/page.tsx
+++ b/src/app/user/[name]/characters/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import dynamic from "next/dynamic";
+import { EyeOff } from "lucide-react";
 import { PageReload } from "@/app/user/_components/PageReload";
 import { Suspense } from "react";
 import Loading from "@/app/loading";
@@ -7,6 +8,7 @@ import type { Metadata, ResolvingMetadata } from "next";
 import SupporterBadge from "@/components/support/SupporterBadge";
 import ShareProfileButton from "@/app/user/_components/ShareProfileButton";
 import DraftProfileButton from "@/app/user/_components/DraftProfileButton";
+import HiddenProfileIndicator from "@/app/user/_components/HiddenProfileIndicator";
 import prisma from "../../../../../prisma/prismaClient";
 import { getLeaderboardProfileHref } from "@/lib/draftHistoryLeaderboardPath";
 import { getCurrentUserCharacterListLayoutPreference } from "@/server/characterListLayoutPreference";
@@ -15,6 +17,11 @@ import {
   getPublicUserProfileByName,
 } from "@/server/publicUserCharacters";
 import { getLeaderboardData } from "@/server/leaderboard";
+import {
+  getProfileViewerContext,
+  isProfileHiddenForViewer,
+} from "@/server/profileViewerContext";
+import { NOINDEX_METADATA } from "@/lib/seo";
 
 const CharacterListOptimized = dynamic(
   () => import("@/app/_components/characters/CharacterListOptimized"),
@@ -42,6 +49,15 @@ export async function generateMetadata(
     return {
       title: "User Not Found",
       description: "This profile could not be found on divoxutils.",
+    };
+  }
+
+  const viewer = await getProfileViewerContext(user.clerkUserId);
+  if (isProfileHiddenForViewer(user.hideProfile, viewer)) {
+    return {
+      title: "Profile Hidden",
+      description: "This user has chosen to keep their character list private.",
+      ...NOINDEX_METADATA,
     };
   }
 
@@ -90,38 +106,75 @@ const CharactersPage = async ({ params, searchParams }: CharactersPageProps) => 
 
   const clerkUserId = user.clerkUserId;
 
-  const [characters, identityLink, preferredDesktopLayout, initialLeaderboardData] = await Promise.all([
-    getPublicCharactersForUser(clerkUserId),
-    prisma.userIdentityLink.findFirst({
-      where: {
-        clerkUserId,
-        provider: "discord",
-        status: "linked",
-      },
-      select: { id: true },
-    }),
-    getCurrentUserCharacterListLayoutPreference(),
-    getLeaderboardData(),
-  ]);
+  const viewer = await getProfileViewerContext(clerkUserId);
+  const isHiddenForViewer = isProfileHiddenForViewer(user.hideProfile, viewer);
+
+  const [identityLink, preferredDesktopLayout, initialLeaderboardData, characters] =
+    await Promise.all([
+      prisma.userIdentityLink.findFirst({
+        where: {
+          clerkUserId,
+          provider: "discord",
+          status: "linked",
+        },
+        select: { id: true },
+      }),
+      getCurrentUserCharacterListLayoutPreference(),
+      getLeaderboardData(),
+      isHiddenForViewer ? Promise.resolve([]) : getPublicCharactersForUser(clerkUserId),
+    ]);
 
   const draftProfileHref = identityLink
     ? getLeaderboardProfileHref(clerkUserId, user.name ?? undefined)
     : undefined;
 
+  const header = (
+    <div className="relative flex items-center justify-center mb-6">
+      <h1 className="text-2xl sm:text-3xl font-semibold text-white inline-flex items-center gap-2">
+        {user.name}
+        {user.supporterTier > 0 && <SupporterBadge tier={user.supporterTier} size="md" />}
+      </h1>
+      <div className="absolute right-0 flex items-center gap-1.5">
+        {user.hideProfile && viewer.canViewHiddenProfile && (
+          <HiddenProfileIndicator isOwner={viewer.isOwner} />
+        )}
+        {draftProfileHref && <DraftProfileButton href={draftProfileHref} />}
+        <ShareProfileButton username={user.name ?? ''} />
+      </div>
+    </div>
+  );
+
+  if (isHiddenForViewer) {
+    return (
+      <div className="bg-gray-900 min-h-screen text-gray-300">
+        <div className="p-4 md:p-8 lg:p-12">
+          <div className="max-w-screen-lg mx-auto">
+            {header}
+            <div className="rounded-xl border border-gray-800 bg-gray-900/60 backdrop-blur-sm">
+              <div className="flex flex-col items-center justify-center py-16 px-6">
+                <div className="flex items-center justify-center w-10 h-10 rounded-full bg-gray-800/80 mb-3">
+                  <EyeOff size={16} strokeWidth={2} className="text-gray-500" />
+                </div>
+                <p className="text-sm font-medium text-gray-300 mb-1">
+                  Character list hidden
+                </p>
+                <p className="text-xs text-gray-400 text-center max-w-xs">
+                  {user.name ?? "This user"} has chosen to keep their
+                  character list private.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="bg-gray-900 min-h-screen text-gray-300">
       <div className="p-4 md:p-8 lg:p-12">
         <div className="max-w-screen-lg mx-auto">
-          <div className="relative flex items-center justify-center mb-6">
-            <h1 className="text-2xl sm:text-3xl font-semibold text-white inline-flex items-center gap-2">
-              {user.name}
-              {user.supporterTier > 0 && <SupporterBadge tier={user.supporterTier} size="md" />}
-            </h1>
-            <div className="absolute right-0 flex items-center gap-1.5">
-              {draftProfileHref && <DraftProfileButton href={draftProfileHref} />}
-              <ShareProfileButton username={user.name ?? ''} />
-            </div>
-          </div>
+          {header}
           <PageReload />
           <Suspense fallback={<Loading />}>
             <CharacterListOptimized

--- a/src/app/user/_components/HiddenProfileIndicator.tsx
+++ b/src/app/user/_components/HiddenProfileIndicator.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { EyeOff } from "lucide-react";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+
+const HiddenProfileIndicator = ({ isOwner }: { isOwner: boolean }) => (
+  <TooltipProvider delayDuration={300}>
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="flex items-center gap-1 h-[30px] px-2 rounded-md border border-gray-800 text-[10px] font-medium uppercase tracking-wide text-gray-500 cursor-default">
+          <EyeOff size={11} strokeWidth={2} />
+          {isOwner ? "Private" : "Hidden"}
+        </span>
+      </TooltipTrigger>
+      <TooltipContent className="max-w-[200px] text-center">
+        {isOwner
+          ? "Only you can see this — hidden from other players"
+          : "Hidden from other players — visible to admins"}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
+
+export default HiddenProfileIndicator;

--- a/src/server/charactersByUserIdApi.ts
+++ b/src/server/charactersByUserIdApi.ts
@@ -1,3 +1,5 @@
+import { isForbiddenViewer } from "@/server/viewerAuthorization";
+
 type CharactersByUserIdDeps = {
   getUserCharactersByUserId: (userId: string) => Promise<unknown[]>;
 };
@@ -5,6 +7,8 @@ type CharactersByUserIdDeps = {
 type CharactersByUserIdInput = {
   method: string;
   userId: string | null;
+  viewerClerkUserId: string | null;
+  viewerIsAdmin: boolean;
 };
 
 type CharactersByUserIdApiResult =
@@ -26,6 +30,10 @@ export async function handleCharactersByUserIdApi(
       body: `Method ${input.method} Not Allowed`,
       bodyType: "text",
     };
+  }
+
+  if (isForbiddenViewer(input.viewerClerkUserId, input.userId, input.viewerIsAdmin)) {
+    return { status: 403, body: { message: "Forbidden" }, bodyType: "json" };
   }
 
   try {

--- a/src/server/charactersByUserIdRouteHandlers.ts
+++ b/src/server/charactersByUserIdRouteHandlers.ts
@@ -3,9 +3,12 @@ import {
   type CharactersByUserIdDeps,
   handleCharactersByUserIdApi,
 } from "@/server/charactersByUserIdApi";
+import { resolveViewer } from "@/server/viewerAuthorization";
 
 type RouteDeps = {
   deps: CharactersByUserIdDeps;
+  getAuthUserId: () => Promise<string | null>;
+  isAdminClerkUserId: (clerkUserId: string | null) => boolean;
 };
 
 export function createCharactersByUserIdRouteHandlers(routeDeps: RouteDeps) {
@@ -15,11 +18,17 @@ export function createCharactersByUserIdRouteHandlers(routeDeps: RouteDeps) {
   ) {
     const params = await context.params;
     const userId = typeof params.id === "string" ? params.id : null;
+    const { viewerClerkUserId, viewerIsAdmin } = await resolveViewer(
+      routeDeps.getAuthUserId,
+      routeDeps.isAdminClerkUserId
+    );
 
     const result = await handleCharactersByUserIdApi(
       {
         method: request.method,
         userId,
+        viewerClerkUserId,
+        viewerIsAdmin,
       },
       routeDeps.deps
     );

--- a/src/server/clerkAuth.ts
+++ b/src/server/clerkAuth.ts
@@ -1,0 +1,6 @@
+import { auth } from "@clerk/nextjs/server";
+
+export async function getClerkAuthUserId(): Promise<string | null> {
+  const { userId } = await auth();
+  return userId;
+}

--- a/src/server/hideProfileApi.ts
+++ b/src/server/hideProfileApi.ts
@@ -1,0 +1,70 @@
+export type HideProfileResponseBody = { hideProfile?: boolean; error?: string };
+
+export type HideProfileApiDeps = {
+  findUserHideProfile: (
+    clerkUserId: string
+  ) => Promise<{ hideProfile: boolean } | null>;
+  findUserByClerkId: (
+    clerkUserId: string
+  ) => Promise<{ clerkUserId: string } | null>;
+  updateUserHideProfile: (
+    clerkUserId: string,
+    hideProfile: boolean
+  ) => Promise<{ hideProfile: boolean }>;
+  revalidatePublicProfile: () => void;
+};
+
+type HideProfileApiInput = {
+  method: string;
+  clerkUserId: string | null;
+  body?: { hideProfile?: unknown } | null;
+};
+
+export type HideProfileApiResult = {
+  status: number;
+  body: HideProfileResponseBody;
+  allow?: string;
+};
+
+export async function handleHideProfileApi(
+  input: HideProfileApiInput,
+  deps: HideProfileApiDeps
+): Promise<HideProfileApiResult> {
+  if (!input.clerkUserId) {
+    return { status: 401, body: { error: "Unauthorized" } };
+  }
+
+  if (input.method === "GET") {
+    const user = await deps.findUserHideProfile(input.clerkUserId);
+
+    if (!user) {
+      return { status: 404, body: { error: "User not found" } };
+    }
+
+    return { status: 200, body: { hideProfile: user.hideProfile } };
+  }
+
+  if (input.method === "PUT") {
+    const hideProfile = input.body?.hideProfile;
+    if (typeof hideProfile !== "boolean") {
+      return { status: 400, body: { error: "Invalid hideProfile" } };
+    }
+
+    const existingUser = await deps.findUserByClerkId(input.clerkUserId);
+
+    if (!existingUser) {
+      return { status: 404, body: { error: "User not found" } };
+    }
+
+    const user = await deps.updateUserHideProfile(input.clerkUserId, hideProfile);
+    deps.revalidatePublicProfile();
+
+    return { status: 200, body: { hideProfile: user.hideProfile } };
+  }
+
+  return {
+    status: 405,
+    allow: "GET, PUT",
+    body: { error: "Method not allowed" },
+  };
+}

--- a/src/server/hideProfileRouteHandlers.ts
+++ b/src/server/hideProfileRouteHandlers.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from "next/server";
+import { type HideProfileApiDeps, handleHideProfileApi } from "@/server/hideProfileApi";
+
+export type HideProfileRouteDeps = {
+  getAuthUserId: () => Promise<string | null>;
+  apiDeps: HideProfileApiDeps;
+};
+
+export function createHideProfileRouteHandlers(routeDeps: HideProfileRouteDeps) {
+  async function runHandler(method: string, request: NextRequest) {
+    const clerkUserId = await routeDeps.getAuthUserId();
+    const body =
+      method === "PUT"
+        ? await request.json().catch(() => null)
+        : null;
+
+    const result = await handleHideProfileApi(
+      {
+        method,
+        clerkUserId,
+        body,
+      },
+      routeDeps.apiDeps
+    );
+
+    const response = NextResponse.json(result.body, { status: result.status });
+    if (result.allow) {
+      response.headers.set("Allow", result.allow);
+    }
+    return response;
+  }
+
+  return {
+    GET: async (request: NextRequest) => runHandler("GET", request),
+    PUT: async (request: NextRequest) => runHandler("PUT", request),
+  };
+}

--- a/src/server/leaderboard.ts
+++ b/src/server/leaderboard.ts
@@ -1,5 +1,6 @@
 import prisma from "../../prisma/prismaClient";
 import { unstable_cache } from "next/cache";
+import type { Prisma } from "@prisma/client";
 
 type LeaderboardCharacter = {
   id: number;
@@ -210,8 +211,13 @@ export const aggregateLeaderboardData = (
   return aggregated.sort((a, b) => b.totalRealmPoints - a.totalRealmPoints);
 };
 
-const getLeaderboardDataUncached = async (): Promise<LeaderboardItem[]> => {
-  const users = await prisma.user.findMany({
+export type FindUsersForLeaderboard = (
+  where: Prisma.UserWhereInput
+) => Promise<LeaderboardUserInput[]>;
+
+const findUsersForLeaderboard: FindUsersForLeaderboard = (where) =>
+  prisma.user.findMany({
+    where,
     select: {
       id: true,
       name: true,
@@ -245,11 +251,15 @@ const getLeaderboardDataUncached = async (): Promise<LeaderboardItem[]> => {
     },
   });
 
+export const getLeaderboardDataUncached = async (
+  findUsers: FindUsersForLeaderboard = findUsersForLeaderboard
+): Promise<LeaderboardItem[]> => {
+  const users = await findUsers({ hideProfile: false });
   return aggregateLeaderboardData(users);
 };
 
 const getCachedLeaderboardData = unstable_cache(
-  getLeaderboardDataUncached,
+  () => getLeaderboardDataUncached(),
   ["leaderboard-data"],
   { revalidate: 60 }
 );

--- a/src/server/profileViewerContext.ts
+++ b/src/server/profileViewerContext.ts
@@ -1,0 +1,33 @@
+import { auth } from "@clerk/nextjs/server";
+import { isAdminClerkUserId } from "@/server/adminAuth";
+
+export type ProfileViewerContext = {
+  isOwner: boolean;
+  isAdmin: boolean;
+  canViewHiddenProfile: boolean;
+};
+
+export async function getProfileViewerContext(
+  profileClerkUserId: string
+): Promise<ProfileViewerContext> {
+  let isOwner = false;
+  let isAdmin = false;
+
+  try {
+    const { userId } = await auth();
+    isAdmin = isAdminClerkUserId(userId);
+    isOwner = Boolean(userId) && userId === profileClerkUserId;
+  } catch {
+    isOwner = false;
+    isAdmin = false;
+  }
+
+  return { isOwner, isAdmin, canViewHiddenProfile: isOwner || isAdmin };
+}
+
+export function isProfileHiddenForViewer(
+  hideProfile: boolean,
+  viewer: Pick<ProfileViewerContext, "canViewHiddenProfile">
+): boolean {
+  return hideProfile && !viewer.canViewHiddenProfile;
+}

--- a/src/server/publicUserCharacters.ts
+++ b/src/server/publicUserCharacters.ts
@@ -9,6 +9,7 @@ type PublicUserProfile = {
   clerkUserId: string;
   name: string | null;
   supporterTier: number;
+  hideProfile: boolean;
 };
 
 type UserCharacterRecord = {
@@ -24,6 +25,7 @@ const getPublicUserProfileByNameUncached = async (
       clerkUserId: true,
       name: true,
       supporterTier: true,
+      hideProfile: true,
     },
   });
 };

--- a/src/server/searchUsersAndCharactersApi.ts
+++ b/src/server/searchUsersAndCharactersApi.ts
@@ -11,6 +11,7 @@ type UserWithCharacters = {
   clerkUserId: string;
   name: string | null;
   supporterTier: number;
+  hideProfile: boolean;
   characters: { character: Character }[];
 };
 
@@ -23,6 +24,7 @@ export type SearchUsersAndCharactersDeps = {
 export type SearchUsersAndCharactersApiInput = {
   method: string;
   nameQuery: unknown;
+  viewerClerkUserId: string | null;
 };
 
 type SearchUsersAndCharactersApiResult =
@@ -94,27 +96,31 @@ export async function handleSearchUsersAndCharactersApi(
 
     const userResults = users
       .map((user) => {
-        const rankedCharacters = user.characters
-          .map((uc) => {
-            const heraldName = uc.character.heraldName;
-            const score = getMatchScore(heraldName, normalizedQuery);
-            const position = getMatchPosition(heraldName, normalizedQuery);
-            return {
-              score,
-              position,
-              characterName: uc.character.characterName,
-              heraldName: heraldName ?? "",
-              className: uc.character.className,
-              totalRealmPoints: uc.character.totalRealmPoints,
-              heraldClassName: uc.character.heraldClassName,
-            };
-          })
-          .filter((character) => character.score > 0)
-          .sort((a, b) => {
-            if (b.score !== a.score) return b.score - a.score;
-            if (a.position !== b.position) return a.position - b.position;
-            return a.heraldName.localeCompare(b.heraldName);
-          });
+        const isOwnHiddenProfile =
+          user.hideProfile && user.clerkUserId === input.viewerClerkUserId;
+        const rankedCharacters = user.hideProfile && !isOwnHiddenProfile
+          ? []
+          : user.characters
+              .map((uc) => {
+                const heraldName = uc.character.heraldName;
+                const score = getMatchScore(heraldName, normalizedQuery);
+                const position = getMatchPosition(heraldName, normalizedQuery);
+                return {
+                  score,
+                  position,
+                  characterName: uc.character.characterName,
+                  heraldName: heraldName ?? "",
+                  className: uc.character.className,
+                  totalRealmPoints: uc.character.totalRealmPoints,
+                  heraldClassName: uc.character.heraldClassName,
+                };
+              })
+              .filter((character) => character.score > 0)
+              .sort((a, b) => {
+                if (b.score !== a.score) return b.score - a.score;
+                if (a.position !== b.position) return a.position - b.position;
+                return a.heraldName.localeCompare(b.heraldName);
+              });
 
         const bestCharacterScore = rankedCharacters[0]?.score ?? 0;
         const bestCharacterPosition =
@@ -129,6 +135,7 @@ export async function handleSearchUsersAndCharactersApi(
           clerkUserId: user.clerkUserId,
           name: user.name,
           supporterTier: user.supporterTier ?? 0,
+          isOwnHiddenProfile,
           score: bestScore,
           userNameScore,
           userNamePosition,

--- a/src/server/searchUsersAndCharactersPagesHandler.ts
+++ b/src/server/searchUsersAndCharactersPagesHandler.ts
@@ -12,6 +12,7 @@ export function createSearchUsersAndCharactersHandler(
       {
         method: req.method ?? "",
         nameQuery: req.query.name,
+        viewerClerkUserId: null,
       },
       deps
     );

--- a/src/server/searchUsersAndCharactersRouteHandlers.ts
+++ b/src/server/searchUsersAndCharactersRouteHandlers.ts
@@ -6,6 +6,7 @@ import {
 
 type SearchUsersAndCharactersRouteDeps = {
   deps: SearchUsersAndCharactersDeps;
+  getAuthUserId: () => Promise<string | null>;
 };
 
 export function createSearchUsersAndCharactersRouteHandlers(
@@ -13,10 +14,12 @@ export function createSearchUsersAndCharactersRouteHandlers(
 ) {
   async function run(method: string, request: NextRequest) {
     const nameQuery = new URL(request.url).searchParams.get("name");
+    const viewerClerkUserId = await routeDeps.getAuthUserId();
     const result = await handleSearchUsersAndCharactersApi(
       {
         method,
         nameQuery,
+        viewerClerkUserId,
       },
       routeDeps.deps
     );

--- a/src/server/services/userCharacterService.ts
+++ b/src/server/services/userCharacterService.ts
@@ -154,8 +154,8 @@ export const deleteUserCharacterByWebId = async (
 };
 
 export async function getUserCharactersByUserName(userName: string) {
-  const user = await prisma.user.findUnique({
-    where: { name: userName },
+  const user = await prisma.user.findFirst({
+    where: { name: userName, hideProfile: false },
     include: {
       characters: {
         select: {

--- a/src/server/userCharactersByUserIdApi.ts
+++ b/src/server/userCharactersByUserIdApi.ts
@@ -2,6 +2,7 @@ import {
   formatRealmRankWithLevel,
   getRealmRankForPoints,
 } from "@/utils/character";
+import { isForbiddenViewer } from "@/server/viewerAuthorization";
 
 type UserCharactersByUserIdDeps = {
   getUserCharactersByUserId: (clerkUserId: string) => Promise<any[]>;
@@ -10,6 +11,8 @@ type UserCharactersByUserIdDeps = {
 type UserCharactersByUserIdInput = {
   method: string;
   userId: string | null;
+  viewerClerkUserId: string | null;
+  viewerIsAdmin: boolean;
 };
 
 type UserCharactersByUserIdApiResult =
@@ -31,6 +34,10 @@ export async function handleUserCharactersByUserIdApi(
       body: `Method ${input.method} Not Allowed`,
       bodyType: "text",
     };
+  }
+
+  if (isForbiddenViewer(input.viewerClerkUserId, input.userId, input.viewerIsAdmin)) {
+    return { status: 403, body: { error: "Forbidden" }, bodyType: "json" };
   }
 
   try {

--- a/src/server/userCharactersByUserIdPagesHandler.ts
+++ b/src/server/userCharactersByUserIdPagesHandler.ts
@@ -4,16 +4,24 @@ import {
   handleUserCharactersByUserIdApi,
 } from "@/server/userCharactersByUserIdApi";
 
+type UserCharactersByUserIdHandlerDeps = UserCharactersByUserIdDeps & {
+  getAuthUserId?: (req: NextApiRequest) => string | null;
+  isAdminClerkUserId?: (clerkUserId: string | null) => boolean;
+};
+
 export const createUserCharactersByUserIdHandler =
-  (deps: UserCharactersByUserIdDeps) =>
+  (deps: UserCharactersByUserIdHandlerDeps) =>
   async (req: NextApiRequest, res: NextApiResponse) => {
     const userId =
       typeof req.query.userId === "string" ? req.query.userId : null;
+    const viewerClerkUserId = deps.getAuthUserId?.(req) ?? null;
 
     const result = await handleUserCharactersByUserIdApi(
       {
         method: req.method ?? "",
         userId,
+        viewerClerkUserId,
+        viewerIsAdmin: deps.isAdminClerkUserId?.(viewerClerkUserId) ?? false,
       },
       deps
     );

--- a/src/server/userCharactersByUserIdRouteHandlers.ts
+++ b/src/server/userCharactersByUserIdRouteHandlers.ts
@@ -3,9 +3,12 @@ import {
   type UserCharactersByUserIdDeps,
   handleUserCharactersByUserIdApi,
 } from "@/server/userCharactersByUserIdApi";
+import { resolveViewer } from "@/server/viewerAuthorization";
 
 type RouteDeps = {
   deps: UserCharactersByUserIdDeps;
+  getAuthUserId: () => Promise<string | null>;
+  isAdminClerkUserId: (clerkUserId: string | null) => boolean;
 };
 
 export function createUserCharactersByUserIdRouteHandlers(routeDeps: RouteDeps) {
@@ -16,10 +19,16 @@ export function createUserCharactersByUserIdRouteHandlers(routeDeps: RouteDeps) 
     ) => {
       const params = await context.params;
       const userId = typeof params.userId === "string" ? params.userId : null;
+      const { viewerClerkUserId, viewerIsAdmin } = await resolveViewer(
+        routeDeps.getAuthUserId,
+        routeDeps.isAdminClerkUserId
+      );
       const result = await handleUserCharactersByUserIdApi(
         {
           method: "GET",
           userId,
+          viewerClerkUserId,
+          viewerIsAdmin,
         },
         routeDeps.deps
       );
@@ -52,6 +61,8 @@ export function createUserCharactersByUserIdRouteHandlers(routeDeps: RouteDeps) 
         {
           method: "POST",
           userId,
+          viewerClerkUserId: null,
+          viewerIsAdmin: false,
         },
         routeDeps.deps
       );

--- a/src/server/viewerAuthorization.ts
+++ b/src/server/viewerAuthorization.ts
@@ -1,0 +1,15 @@
+export function isForbiddenViewer(
+  viewerClerkUserId: string | null,
+  resourceClerkUserId: string | null,
+  viewerIsAdmin: boolean
+): boolean {
+  return viewerClerkUserId !== resourceClerkUserId && !viewerIsAdmin;
+}
+
+export async function resolveViewer(
+  getAuthUserId: () => Promise<string | null>,
+  isAdminClerkUserId: (clerkUserId: string | null) => boolean
+): Promise<{ viewerClerkUserId: string | null; viewerIsAdmin: boolean }> {
+  const viewerClerkUserId = await getAuthUserId();
+  return { viewerClerkUserId, viewerIsAdmin: isAdminClerkUserId(viewerClerkUserId) };
+}

--- a/tests/characters-by-user-id.route.test.ts
+++ b/tests/characters-by-user-id.route.test.ts
@@ -7,6 +7,8 @@ test("charactersByUser GET returns 400 for missing id", async () => {
     deps: {
       getUserCharactersByUserId: async () => [],
     },
+    getAuthUserId: async () => "user_1",
+    isAdminClerkUserId: () => false,
   });
 
   const response = await handlers.GET(new Request("http://localhost") as any, {
@@ -17,11 +19,29 @@ test("charactersByUser GET returns 400 for missing id", async () => {
   assert.deepEqual(await response.json(), { message: "User ID must be a string." });
 });
 
+test("charactersByUser GET returns 403 for a different user", async () => {
+  const handlers = createCharactersByUserIdRouteHandlers({
+    deps: {
+      getUserCharactersByUserId: async () => [],
+    },
+    getAuthUserId: async () => "user_2",
+    isAdminClerkUserId: () => false,
+  });
+
+  const response = await handlers.GET(new Request("http://localhost") as any, {
+    params: { id: "user_1" },
+  });
+
+  assert.equal(response.status, 403);
+});
+
 test("charactersByUser GET returns 404 when empty", async () => {
   const handlers = createCharactersByUserIdRouteHandlers({
     deps: {
       getUserCharactersByUserId: async () => [],
     },
+    getAuthUserId: async () => "user_1",
+    isAdminClerkUserId: () => false,
   });
 
   const response = await handlers.GET(new Request("http://localhost") as any, {
@@ -34,11 +54,30 @@ test("charactersByUser GET returns 404 when empty", async () => {
   });
 });
 
-test("charactersByUser GET returns characters", async () => {
+test("charactersByUser GET returns characters for the owner", async () => {
   const handlers = createCharactersByUserIdRouteHandlers({
     deps: {
       getUserCharactersByUserId: async () => [{ characterId: 8 }],
     },
+    getAuthUserId: async () => "user_1",
+    isAdminClerkUserId: () => false,
+  });
+
+  const response = await handlers.GET(new Request("http://localhost") as any, {
+    params: { id: "user_1" },
+  });
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), [{ characterId: 8 }]);
+});
+
+test("charactersByUser GET returns characters for an admin viewer", async () => {
+  const handlers = createCharactersByUserIdRouteHandlers({
+    deps: {
+      getUserCharactersByUserId: async () => [{ characterId: 8 }],
+    },
+    getAuthUserId: async () => "admin_1",
+    isAdminClerkUserId: () => true,
   });
 
   const response = await handlers.GET(new Request("http://localhost") as any, {
@@ -54,6 +93,8 @@ test("charactersByUser POST returns 405 with allow header", async () => {
     deps: {
       getUserCharactersByUserId: async () => [],
     },
+    getAuthUserId: async () => "user_1",
+    isAdminClerkUserId: () => false,
   });
 
   const response = await handlers.POST(

--- a/tests/leaderboard.aggregate.test.ts
+++ b/tests/leaderboard.aggregate.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
-import { aggregateLeaderboardData } from "../src/server/leaderboard";
+import { aggregateLeaderboardData, getLeaderboardDataUncached } from "../src/server/leaderboard";
 
 test("aggregateLeaderboardData aggregates totals and sorts descending", () => {
   const data = [
@@ -188,4 +188,46 @@ test("aggregateLeaderboardData uses effective death blow baseline for weekly gua
     leaderboardSource.includes("character.deathBlowsLastWeek !== effectiveTotalDeathBlows"),
     true
   );
+});
+
+test("getLeaderboardDataUncached queries with hideProfile: false and aggregates the result", async () => {
+  let capturedWhere: unknown;
+  const result = await getLeaderboardDataUncached(async (where) => {
+    capturedWhere = where;
+    return [
+      {
+        id: 1,
+        name: "Alice",
+        clerkUserId: "u_1",
+        characters: [
+          {
+            character: {
+              id: 101,
+              totalRealmPoints: 1000,
+              totalKills: 100,
+              totalSoloKills: 10,
+              totalDeaths: 5,
+              totalDeathBlows: 5,
+              killsLastWeek: 0,
+              deathsLastWeek: 0,
+              deathBlowsLastWeek: 0,
+              realmPointsLastWeek: 0,
+              soloKillsLastWeek: 0,
+              lastUpdated: null,
+              heraldRealmPoints: 1000,
+              heraldTotalKills: 100,
+              heraldTotalDeaths: 5,
+              heraldTotalSoloKills: 10,
+              heraldTotalDeathBlows: 5,
+            },
+          },
+        ],
+      },
+    ];
+  });
+
+  assert.deepEqual(capturedWhere, { hideProfile: false });
+  assert.equal(result.length, 1);
+  assert.equal(result[0].userName, "Alice");
+  assert.equal(result[0].totalRealmPoints, 1000);
 });

--- a/tests/my-characters.crud.test.ts
+++ b/tests/my-characters.crud.test.ts
@@ -228,6 +228,7 @@ test("userCharactersByUserId handler returns 400 for invalid userId", async () =
 test("userCharactersByUserId handler returns [] and no-store cache header", async () => {
   const handler = createUserCharactersByUserIdHandler({
     getUserCharactersByUserId: async () => [],
+    getAuthUserId: () => "user_123",
   });
 
   const req = createMockRequest({
@@ -248,6 +249,7 @@ test("userCharactersByUserId handler returns [] and no-store cache header", asyn
 
 test("userCharactersByUserId handler maps character payload", async () => {
   const handler = createUserCharactersByUserIdHandler({
+    getAuthUserId: () => "user_123",
     getUserCharactersByUserId: async () => [
       {
         user: { clerkUserId: "user_123" },
@@ -320,6 +322,7 @@ test("userCharactersByUserId handler maps character payload", async () => {
 
 test("userCharactersByUserId handler falls back to query userId when user is missing", async () => {
   const handler = createUserCharactersByUserIdHandler({
+    getAuthUserId: () => "user_fallback",
     getUserCharactersByUserId: async () => [
       {
         user: null,
@@ -387,6 +390,23 @@ test("userCharactersByUserId handler falls back to query userId when user is mis
     userId: "user_fallback",
     webId: "xyz",
   });
+});
+
+test("userCharactersByUserId handler returns 403 for a different user", async () => {
+  const handler = createUserCharactersByUserIdHandler({
+    getUserCharactersByUserId: async () => [],
+    getAuthUserId: () => "someone_else",
+  });
+
+  const req = createMockRequest({
+    method: "GET",
+    query: { userId: "user_123" },
+  });
+  const res = createMockResponse();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 403);
 });
 
 test("userCharactersByUserId handler rejects unsupported methods", async () => {

--- a/tests/profile-viewer-context.test.ts
+++ b/tests/profile-viewer-context.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isProfileHiddenForViewer } from "../src/server/profileViewerContext";
+
+test("isProfileHiddenForViewer hides a hidden profile from a stranger", () => {
+  assert.equal(
+    isProfileHiddenForViewer(true, { canViewHiddenProfile: false }),
+    true
+  );
+});
+
+test("isProfileHiddenForViewer shows a hidden profile to its owner", () => {
+  assert.equal(
+    isProfileHiddenForViewer(true, { canViewHiddenProfile: true }),
+    false
+  );
+});
+
+test("isProfileHiddenForViewer shows a hidden profile to an admin", () => {
+  assert.equal(
+    isProfileHiddenForViewer(true, { canViewHiddenProfile: true }),
+    false
+  );
+});
+
+test("isProfileHiddenForViewer never hides a visible profile", () => {
+  assert.equal(
+    isProfileHiddenForViewer(false, { canViewHiddenProfile: false }),
+    false
+  );
+  assert.equal(
+    isProfileHiddenForViewer(false, { canViewHiddenProfile: true }),
+    false
+  );
+});

--- a/tests/search-users-characters.api.test.ts
+++ b/tests/search-users-characters.api.test.ts
@@ -1,6 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { createSearchUsersAndCharactersHandler } from "../src/server/searchUsersAndCharactersPagesHandler";
+import { handleSearchUsersAndCharactersApi } from "../src/server/searchUsersAndCharactersApi";
 
 function createMockResponse() {
   const res: any = {
@@ -119,6 +120,7 @@ test("search users and characters ranks exact, prefix, then contains", async () 
         clerkUserId: "u_exact_character",
         name: "alpha",
         supporterTier: 0,
+        hideProfile: false,
         characters: [
           { character: makeCharacter({ heraldName: "xkenx", characterName: "XKenX" }) },
           { character: makeCharacter({ heraldName: "ken", characterName: "Ken" }) },
@@ -131,6 +133,7 @@ test("search users and characters ranks exact, prefix, then contains", async () 
         clerkUserId: "u_prefix_user",
         name: "kennyUser",
         supporterTier: 0,
+        hideProfile: false,
         characters: [],
       },
       {
@@ -138,6 +141,7 @@ test("search users and characters ranks exact, prefix, then contains", async () 
         clerkUserId: "u_contains_user",
         name: "xkenxUser",
         supporterTier: 0,
+        hideProfile: false,
         characters: [],
       },
       {
@@ -145,6 +149,7 @@ test("search users and characters ranks exact, prefix, then contains", async () 
         clerkUserId: "u_filtered_out",
         name: "nomatch",
         supporterTier: 0,
+        hideProfile: false,
         characters: [{ character: makeCharacter({ heraldName: null }) }],
       },
     ],
@@ -175,6 +180,7 @@ test("search users and characters supports user-name-only match with zero charac
         clerkUserId: "u_k3nco",
         name: "k3nco",
         supporterTier: 0,
+        hideProfile: false,
         characters: [{ character: makeCharacter({ heraldName: null, characterName: "kenco" }) }],
       },
     ],
@@ -192,7 +198,81 @@ test("search users and characters supports user-name-only match with zero charac
         clerkUserId: "u_k3nco",
         name: "k3nco",
         supporterTier: 0,
+        isOwnHiddenProfile: false,
         characters: [],
+      },
+    ],
+  });
+});
+
+test("search users and characters omits character details for a hidden profile but still matches by name", async () => {
+  const handler = createSearchUsersAndCharactersHandler({
+    findUsers: async () => [
+      {
+        id: 70,
+        clerkUserId: "u_hidden",
+        name: "kenhidden",
+        supporterTier: 0,
+        hideProfile: true,
+        characters: [{ character: makeCharacter({ heraldName: "ken", characterName: "Ken" }) }],
+      },
+    ],
+  });
+  const req = createMockRequest({ query: { name: "ken" } });
+  const res = createMockResponse();
+
+  await handler(req, res);
+
+  assert.equal(res.statusCode, 200);
+  assert.deepEqual(res.body, {
+    users: [
+      {
+        id: 70,
+        clerkUserId: "u_hidden",
+        name: "kenhidden",
+        supporterTier: 0,
+        isOwnHiddenProfile: false,
+        characters: [],
+      },
+    ],
+  });
+});
+
+test("search users and characters shows characters for the viewer's own hidden profile with a marker", async () => {
+  const result = await handleSearchUsersAndCharactersApi(
+    { method: "GET", nameQuery: "ken", viewerClerkUserId: "u_hidden" },
+    {
+      findUsers: async () => [
+        {
+          id: 70,
+          clerkUserId: "u_hidden",
+          name: "kenhidden",
+          supporterTier: 0,
+          hideProfile: true,
+          characters: [{ character: makeCharacter({ heraldName: "ken", characterName: "Ken" }) }],
+        },
+      ],
+    }
+  );
+
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, {
+    users: [
+      {
+        id: 70,
+        clerkUserId: "u_hidden",
+        name: "kenhidden",
+        supporterTier: 0,
+        isOwnHiddenProfile: true,
+        characters: [
+          {
+            characterName: "Ken",
+            heraldName: "ken",
+            className: "Armsman",
+            totalRealmPoints: 1,
+            heraldClassName: "Armsman",
+          },
+        ],
       },
     ],
   });
@@ -206,6 +286,7 @@ test("search users and characters prefers earlier match position in tie", async 
         clerkUserId: "u_late_match",
         name: "zzzkenco",
         supporterTier: 0,
+        hideProfile: false,
         characters: [],
       },
       {
@@ -213,6 +294,7 @@ test("search users and characters prefers earlier match position in tie", async 
         clerkUserId: "u_early_match",
         name: "kencozzz",
         supporterTier: 0,
+        hideProfile: false,
         characters: [],
       },
       {
@@ -220,6 +302,7 @@ test("search users and characters prefers earlier match position in tie", async 
         clerkUserId: "u_middle_match",
         name: "zzkencoz",
         supporterTier: 0,
+        hideProfile: false,
         characters: [],
       },
     ],

--- a/tests/search-users-characters.route.test.ts
+++ b/tests/search-users-characters.route.test.ts
@@ -4,6 +4,7 @@ import { createSearchUsersAndCharactersRouteHandlers } from "../src/server/searc
 
 test("search users and characters route GET returns users", async () => {
   const handlers = createSearchUsersAndCharactersRouteHandlers({
+    getAuthUserId: async () => null,
     deps: {
       findUsers: async ({ normalizedQuery }) => [
         {
@@ -11,6 +12,7 @@ test("search users and characters route GET returns users", async () => {
           clerkUserId: "u_7",
           name: normalizedQuery,
           supporterTier: 1,
+          hideProfile: false,
           characters: [],
         },
       ],
@@ -29,14 +31,42 @@ test("search users and characters route GET returns users", async () => {
         clerkUserId: "u_7",
         name: "kenco",
         supporterTier: 1,
+        isOwnHiddenProfile: false,
         characters: [],
       },
     ],
   });
 });
 
+test("search users and characters route marks the viewer's own hidden profile", async () => {
+  const handlers = createSearchUsersAndCharactersRouteHandlers({
+    getAuthUserId: async () => "u_7",
+    deps: {
+      findUsers: async ({ normalizedQuery }) => [
+        {
+          id: 7,
+          clerkUserId: "u_7",
+          name: normalizedQuery,
+          supporterTier: 1,
+          hideProfile: true,
+          characters: [],
+        },
+      ],
+    },
+  });
+
+  const response = await handlers.GET(
+    new Request("http://localhost/api/searchUsersAndCharacters?name=Kenco") as any
+  );
+
+  assert.equal(response.status, 200);
+  const body = (await response.json()) as { users: Array<{ isOwnHiddenProfile: boolean }> };
+  assert.equal(body.users[0].isOwnHiddenProfile, true);
+});
+
 test("search users and characters route POST returns 405 and Allow header", async () => {
   const handlers = createSearchUsersAndCharactersRouteHandlers({
+    getAuthUserId: async () => null,
     deps: {
       findUsers: async () => [],
     },

--- a/tests/user-characters.app-routes.test.ts
+++ b/tests/user-characters.app-routes.test.ts
@@ -3,7 +3,21 @@ import assert from "node:assert/strict";
 import { createUserCharactersByUserIdRouteHandlers } from "../src/server/userCharactersByUserIdRouteHandlers";
 import { createUserCharacterRouteHandlers } from "../src/server/userCharacterRouteHandlers";
 
-test("userCharactersByUserId route GET returns mapped payload", async () => {
+test("userCharactersByUserId route GET returns 403 for a different user", async () => {
+  const handlers = createUserCharactersByUserIdRouteHandlers({
+    deps: { getUserCharactersByUserId: async () => [] },
+    getAuthUserId: async () => "user_2",
+    isAdminClerkUserId: () => false,
+  });
+
+  const response = await handlers.GET(new Request("http://localhost") as any, {
+    params: { userId: "user_1" },
+  });
+
+  assert.equal(response.status, 403);
+});
+
+test("userCharactersByUserId route GET returns mapped payload for the owner", async () => {
   const handlers = createUserCharactersByUserIdRouteHandlers({
     deps: {
       getUserCharactersByUserId: async () => [
@@ -55,6 +69,8 @@ test("userCharactersByUserId route GET returns mapped payload", async () => {
         },
       ],
     },
+    getAuthUserId: async () => "user_1",
+    isAdminClerkUserId: () => false,
   });
 
   const response = await handlers.GET(new Request("http://localhost") as any, {
@@ -74,6 +90,8 @@ test("userCharactersByUserId route GET returns mapped payload", async () => {
 test("userCharactersByUserId route POST returns 405", async () => {
   const handlers = createUserCharactersByUserIdRouteHandlers({
     deps: { getUserCharactersByUserId: async () => [] },
+    getAuthUserId: async () => "user_1",
+    isAdminClerkUserId: () => false,
   });
 
   const response = await handlers.POST(new Request("http://localhost") as any, {

--- a/tests/user.hide-profile.api.test.ts
+++ b/tests/user.hide-profile.api.test.ts
@@ -1,0 +1,96 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { handleHideProfileApi, type HideProfileApiDeps } from "../src/server/hideProfileApi";
+
+function createDeps(overrides?: Partial<HideProfileApiDeps>): HideProfileApiDeps {
+  return {
+    findUserHideProfile: async () => ({ hideProfile: false }),
+    findUserByClerkId: async () => ({ clerkUserId: "user_1" }),
+    updateUserHideProfile: async (_clerkUserId, hideProfile) => ({ hideProfile }),
+    revalidatePublicProfile: () => {},
+    ...overrides,
+  };
+}
+
+test("hide profile rejects unauthenticated requests", async () => {
+  const result = await handleHideProfileApi(
+    { method: "GET", clerkUserId: null },
+    createDeps()
+  );
+
+  assert.equal(result.status, 401);
+  assert.deepEqual(result.body, { error: "Unauthorized" });
+});
+
+test("hide profile GET returns current value", async () => {
+  const result = await handleHideProfileApi(
+    { method: "GET", clerkUserId: "user_1" },
+    createDeps({ findUserHideProfile: async () => ({ hideProfile: true }) })
+  );
+
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, { hideProfile: true });
+});
+
+test("hide profile GET returns 404 when user missing", async () => {
+  const result = await handleHideProfileApi(
+    { method: "GET", clerkUserId: "user_1" },
+    createDeps({ findUserHideProfile: async () => null })
+  );
+
+  assert.equal(result.status, 404);
+  assert.deepEqual(result.body, { error: "User not found" });
+});
+
+test("hide profile PUT rejects non-boolean value", async () => {
+  const result = await handleHideProfileApi(
+    { method: "PUT", clerkUserId: "user_1", body: { hideProfile: "yes" } },
+    createDeps()
+  );
+
+  assert.equal(result.status, 400);
+  assert.deepEqual(result.body, { error: "Invalid hideProfile" });
+});
+
+test("hide profile PUT returns 404 when user missing", async () => {
+  const result = await handleHideProfileApi(
+    { method: "PUT", clerkUserId: "user_1", body: { hideProfile: true } },
+    createDeps({ findUserByClerkId: async () => null })
+  );
+
+  assert.equal(result.status, 404);
+  assert.deepEqual(result.body, { error: "User not found" });
+});
+
+test("hide profile PUT saves value and revalidates the public profile cache", async () => {
+  let saved: boolean | null = null;
+  let revalidated = false;
+  const result = await handleHideProfileApi(
+    { method: "PUT", clerkUserId: "user_1", body: { hideProfile: true } },
+    createDeps({
+      updateUserHideProfile: async (_clerkUserId, hideProfile) => {
+        saved = hideProfile;
+        return { hideProfile };
+      },
+      revalidatePublicProfile: () => {
+        revalidated = true;
+      },
+    })
+  );
+
+  assert.equal(saved, true);
+  assert.equal(revalidated, true);
+  assert.equal(result.status, 200);
+  assert.deepEqual(result.body, { hideProfile: true });
+});
+
+test("hide profile rejects unsupported methods", async () => {
+  const result = await handleHideProfileApi(
+    { method: "DELETE", clerkUserId: "user_1" },
+    createDeps()
+  );
+
+  assert.equal(result.status, 405);
+  assert.equal(result.allow, "GET, PUT");
+  assert.deepEqual(result.body, { error: "Method not allowed" });
+});

--- a/tests/user.hide-profile.route.test.ts
+++ b/tests/user.hide-profile.route.test.ts
@@ -1,0 +1,111 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { createHideProfileRouteHandlers } from "../src/server/hideProfileRouteHandlers";
+
+function createHandlers(options?: {
+  userId?: string | null;
+  findUserHideProfile?: () => Promise<{ hideProfile: boolean } | null>;
+  findUserByClerkId?: () => Promise<{ clerkUserId: string } | null>;
+  updateUserHideProfile?: (
+    clerkUserId: string,
+    hideProfile: boolean
+  ) => Promise<{ hideProfile: boolean }>;
+  revalidatePublicProfile?: () => void;
+}) {
+  const userId =
+    options && Object.prototype.hasOwnProperty.call(options, "userId")
+      ? options.userId ?? null
+      : "user_1";
+
+  return createHideProfileRouteHandlers({
+    getAuthUserId: async () => userId,
+    apiDeps: {
+      findUserHideProfile:
+        options?.findUserHideProfile ?? (async () => ({ hideProfile: false })),
+      findUserByClerkId:
+        options?.findUserByClerkId ?? (async () => ({ clerkUserId: "user_1" })),
+      updateUserHideProfile:
+        options?.updateUserHideProfile ??
+        (async (_clerkUserId, hideProfile) => ({ hideProfile })),
+      revalidatePublicProfile: options?.revalidatePublicProfile ?? (() => {}),
+    },
+  });
+}
+
+test("route GET rejects unauthenticated requests", async () => {
+  const handlers = createHandlers({ userId: null });
+  const request = new Request("http://localhost/api/user/preferences/hide-profile");
+
+  const response = await handlers.GET(request as any);
+
+  assert.equal(response.status, 401);
+  assert.deepEqual(await response.json(), { error: "Unauthorized" });
+});
+
+test("route GET returns current value", async () => {
+  const handlers = createHandlers({
+    findUserHideProfile: async () => ({ hideProfile: true }),
+  });
+  const request = new Request("http://localhost/api/user/preferences/hide-profile");
+
+  const response = await handlers.GET(request as any);
+
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { hideProfile: true });
+});
+
+test("route PUT validates hideProfile value", async () => {
+  const handlers = createHandlers();
+  const request = new Request("http://localhost/api/user/preferences/hide-profile", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hideProfile: "invalid" }),
+  });
+
+  const response = await handlers.PUT(request as any);
+
+  assert.equal(response.status, 400);
+  assert.deepEqual(await response.json(), { error: "Invalid hideProfile" });
+});
+
+test("route PUT returns 404 when user missing", async () => {
+  const handlers = createHandlers({
+    findUserByClerkId: async () => null,
+  });
+  const request = new Request("http://localhost/api/user/preferences/hide-profile", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hideProfile: true }),
+  });
+
+  const response = await handlers.PUT(request as any);
+
+  assert.equal(response.status, 404);
+  assert.deepEqual(await response.json(), { error: "User not found" });
+});
+
+test("route PUT saves and revalidates on success", async () => {
+  let saved: boolean | null = null;
+  let revalidated = false;
+  const handlers = createHandlers({
+    updateUserHideProfile: async (_clerkUserId, hideProfile) => {
+      saved = hideProfile;
+      return { hideProfile };
+    },
+    revalidatePublicProfile: () => {
+      revalidated = true;
+    },
+  });
+  const request = new Request("http://localhost/api/user/preferences/hide-profile", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ hideProfile: true }),
+  });
+
+  const response = await handlers.PUT(request as any);
+
+  assert.equal(saved, true);
+  assert.equal(revalidated, true);
+  assert.equal(response.status, 200);
+  assert.deepEqual(await response.json(), { hideProfile: true });
+});

--- a/tests/viewer-authorization.test.ts
+++ b/tests/viewer-authorization.test.ts
@@ -1,0 +1,35 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { isForbiddenViewer, resolveViewer } from "../src/server/viewerAuthorization";
+
+test("isForbiddenViewer forbids a different, non-admin viewer", () => {
+  assert.equal(isForbiddenViewer("user_2", "user_1", false), true);
+});
+
+test("isForbiddenViewer allows the owner", () => {
+  assert.equal(isForbiddenViewer("user_1", "user_1", false), false);
+});
+
+test("isForbiddenViewer allows an admin viewing anyone", () => {
+  assert.equal(isForbiddenViewer("admin_1", "user_1", true), false);
+});
+
+test("isForbiddenViewer forbids an anonymous viewer", () => {
+  assert.equal(isForbiddenViewer(null, "user_1", false), true);
+});
+
+test("resolveViewer combines the auth lookup and admin check", async () => {
+  const result = await resolveViewer(
+    async () => "user_1",
+    (clerkUserId) => clerkUserId === "user_1"
+  );
+  assert.deepEqual(result, { viewerClerkUserId: "user_1", viewerIsAdmin: true });
+});
+
+test("resolveViewer handles an anonymous viewer", async () => {
+  const result = await resolveViewer(
+    async () => null,
+    () => false
+  );
+  assert.deepEqual(result, { viewerClerkUserId: null, viewerIsAdmin: false });
+});


### PR DESCRIPTION
## Summary
- Adds a per-user `hideProfile` toggle on the My Characters page that hides a user's characters from other players' view of their public profile, from leaderboards, and from character details in quick search (they're still findable by name in search and in the user directory)
- Owners and admins always see the full character list normally; everyone else sees a small "hidden" placeholder on the profile page
- Fixes two pre-existing endpoints (`/api/userCharactersByUserId`, `/api/charactersByUser`) that returned any user's character data to any caller with no ownership check
- Fixes the Discord-bot-facing lookup endpoints (`/api/users/characters/[name]`, `/api/users/stats/[name]`, `/api/characters/stats/[name]`) to also respect the hide flag, since they previously bypassed it entirely

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test:feature` (585 tests)
- [x] Manually verified in browser: toggle persists across reload and survives rapid clicking, hidden profile shows the placeholder to strangers while owner/admin still see it in full, leaderboard and search correctly exclude/include hidden users, own hidden entry still visible when searching yourself
- [x] Production DB migration applied (`hideProfile` column added to `User`)
